### PR TITLE
Remove mxcp.lsp from the packages to install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ vault = [
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["mxcp", "mxcp.cli", "mxcp.config", "mxcp.config.schemas", "mxcp.server", "mxcp.auth", "mxcp.drift", "mxcp.endpoints", "mxcp.engine", "mxcp.plugins", "mxcp.policies"]
+packages = ["mxcp", "mxcp.audit", "mxcp.cli", "mxcp.config", "mxcp.config.schemas", "mxcp.server", "mxcp.auth", "mxcp.drift", "mxcp.endpoints", "mxcp.engine", "mxcp.plugins", "mxcp.policies"]
 include-package-data = true
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
It appears there and prevent to install mxcp. I believe there's no lsp code yet? If so I suppose we should remove it.

But maybe the whole lsp code was supposed to be found and wasn't 'git added'?