### PR TITLE
Enforce a syntax to tool names + fix call to pydantic create_model

### DIFF
--- a/src/mxcp/endpoints/schemas/endpoint-schema-1.0.0.json
+++ b/src/mxcp/endpoints/schemas/endpoint-schema-1.0.0.json
@@ -43,7 +43,11 @@
       "type": "object",
       "required": ["name", "source"],
       "properties": {
-        "name": { "type": "string", "description": "Name of this tool." },
+        "name": { 
+          "type": "string", 
+          "description": "Name of this tool.",
+          "minLength": 1
+        },
         "description": { "type": "string", "description": "Description of this tool." },
         "tags": {
           "type": "array",
@@ -154,6 +158,11 @@
           "minLength": 1,
           "maxLength": 255
         },
+        "name": { 
+          "type": "string", 
+          "description": "Name of this resource.",
+          "minLength": 1
+        },
         "description": { "type": "string", "description": "Description of this resource." },
         "tags": {
           "type": "array",
@@ -231,7 +240,11 @@
       "type": "object",
       "required": ["name"],
       "properties": {
-        "name": { "type": "string", "description": "Logical name identifying this prompt." },
+        "name": { 
+          "type": "string", 
+          "description": "Logical name identifying this prompt.",
+          "minLength": 1
+        },
         "description": { "type": "string", "description": "Description of this prompt." },
         "tags": {
           "type": "array",
@@ -275,7 +288,9 @@
       "properties": {
         "name": { 
           "type": "string", 
-          "description": "Parameter name." 
+          "description": "Parameter name.",
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+          "minLength": 1
         },
         "description": { 
           "type": "string", 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -193,10 +193,8 @@ def test_endpoint_registration(mcp_server):
     # Register endpoints
     mcp_server.register_endpoints()
     
-    # Verify endpoints were registered
-    # Note: This is a basic test - we'll need more comprehensive tests
-    # that verify the actual MCP server behavior
-    assert len(mcp_server.endpoints) > 0
+    # Verify no endpoints were skipped
+    assert len(mcp_server.skipped_endpoints) == 0
 
 @pytest.mark.asyncio
 async def test_server_transport(mcp_server):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -94,6 +94,18 @@ def test_validate_invalid_type(validation_repo_path, site_config, user_config, t
     finally:
         os.chdir(original_dir)
 
+def test_validate_invalid_parameter_name(validation_repo_path, site_config, user_config, test_profile):
+    """Test validation of an endpoint with an invalid parameter name."""
+    original_dir = os.getcwd()
+    os.chdir(validation_repo_path)
+    try:
+        endpoint_path = "endpoints/invalid_parameter_name.yml"
+        result = validate_endpoint(endpoint_path, user_config, site_config, test_profile)
+        assert result["status"] == "error"
+        assert "schema validation error: 'user/id' does not match" in result["message"].lower()
+    finally:
+        os.chdir(original_dir)
+
 def test_validate_missing_param(validation_repo_path, site_config, user_config, test_profile):
     """Test validation of an endpoint with missing parameter."""
     original_dir = os.getcwd()


### PR DESCRIPTION
This patch introduces some *schema-level* enforcement for valid names in tool/resource/prompt/parameter declarations.

At the same time, also makes sure we generate valid python function names. The goal is to prevent runtime failures due to invalid identifiers (e.g. `tool-name`, `task/id`) that break `makefun`.

The MCP spec _doesn’t enforce a strict syntax for tool or parameter names_. One has to eventually fit what JSON-RPC enforces: any string is allowed, except those starting with `rpc.` (reserved in JSON-RPC). I updated the code to still allow flexible names (minimum one character) and auto-generate valid Python identifiers when needed. For example, a tool like `task/code-from-id` is now accepted and was used by `mcp-cli`.

> [!NOTE]
> Clients may impose their own constraints—for example, when loading `task/code-from-id` in Claude Desktop, I found out it enforces a pattern: `^[a-zA-Z0-9_-]{1,64}$`. Given that, it feels somewhat arbitrary for us to enforce a naming rule ourselves, but it’s something we can consider. Open for discussion.

I left a pattern constraint on parameter names since those have to match what DuckDB allows. They are OK with Python.

Also while browsing tests I got interested in the one that loads endpoints from fixtures, and noticed after running endpoint registration it asserts on `len(mcp.endpoints)`, which doesn't ensure endpoints were registered (the list is populated before and used during registration). I fixed the test to assert on `skipped_endpoints` and found out the code was failing to register the supposedely valid example endpoint. It seems to be due to a called `create_model` being passed an argument of the wrong type (it expects a `ConfigDict`).