### PR TITLE
fix: requires python >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "MXCP: Model eXecution + Context Protocol"
 authors = [{ name = "RAW Labs SA", email = "hello@raw-labs.com" }]
 readme = "README.md"
 license = "BUSL-1.1"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.9.0",  # Official MCP Python SDK
     "click>=8.1.7",
@@ -67,14 +67,14 @@ asyncio_mode = "auto"  # Enable async test support
 
 [tool.black]
 line-length = 100
-target-version = ["py39"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"
 line_length = 100
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,4 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+


### PR DESCRIPTION
Since we require 

["mcp>=1.9.0"](https://github.com/raw-labs/mxcp/blob/main/pyproject.toml#L14)

and since this lib requires 

[requires-python = ">=3.10"](https://github.com/modelcontextprotocol/python-sdk/blob/main/pyproject.toml#L5)

3.10 will be our minimal required version as well