### PR TITLE
Erroneous quotes when installing extensions from repos.

### DIFF
--- a/src/mxcp/engine/extension_loader.py
+++ b/src/mxcp/engine/extension_loader.py
@@ -36,7 +36,7 @@ def _load_extension(con, name: str, repo: str = None):
     """
     try:
         if repo:
-            con.sql(f"INSTALL {name} FROM '{repo}'; LOAD {name};")
+            con.sql(f"INSTALL {name} FROM {repo}; LOAD {name};")
             logging.info(f"DuckDB extension '{name}' from '{repo}' loaded.")
         else:
             con.sql(f"INSTALL {name}; LOAD {name};")


### PR DESCRIPTION
If we are trying to use extensions from a repo.
For example nanodbc from community, see mxcp-site.yml example:

```yaml
mxcp: 1.0.0
project: odbc-sqlite
profile: default
extensions:
  - name: "nanodbc"
    repo: "community"
```
The code in extension_loader.py adds quotes around the repo:
```sql
INSTALL nanodbc FROM 'community';
```

Which leads to the following errors loading the extension:
```
WARNING:root:Failed to install DuckDB extension 'nanodbc': Invalid Input Error: Installing extension 'nanodbc' failed. The extension is already installed but the origin is different.
Currently installed extension is from repository 'http://community-extensions.duckdb.org', while the extension to be installed is from repository 'community'.
```

The correct statement is:
```sql
INSTALL nanodbc FROM community;
```
