### PR TITLE
Fix for  f-string: unmatched '[' error

### DIFF
--- a/src/mxcp/agent_help/renderer.py
+++ b/src/mxcp/agent_help/renderer.py
@@ -141,7 +141,7 @@ class HelpRenderer:
                 priority_text = ""
                 if subcat.get('agent_priority'):
                     priority_color = 'red' if subcat['agent_priority'] == 'high' else 'yellow' if subcat['agent_priority'] == 'medium' else 'green'
-                    priority_text = f" {click.style(f'[{subcat['agent_priority'].upper()}]', fg=priority_color)}"
+                    priority_text = ' ' + click.style(f'[{subcat["agent_priority"].upper()}]', fg=priority_color)
                 
                 lines.append(f"{click.style(f'{i:2}.', fg='blue')} {click.style(subcat['name'], fg='green', bold=True)}{priority_text}")
                 lines.append(f"    {subcat['description']}")


### PR DESCRIPTION
When running `mxcp --help` I got the following error:
```bash
mxcp --help 
Traceback (most recent call last):
  File "/home/cesar/.pyenv/versions/mxcp/bin/mxcp", line 5, in <module>
    from mxcp.__main__ import cli
  File "/home/cesar/development/mxcp/src/mxcp/__main__.py", line 16, in <module>
    from mxcp.cli.agent_help import agent_help
  File "/home/cesar/development/mxcp/src/mxcp/cli/agent_help.py", line 6, in <module>
    from mxcp.agent_help.renderer import HelpRenderer
  File "/home/cesar/development/mxcp/src/mxcp/agent_help/renderer.py", line 144
    (click.style(f'[{subcat['agent_priority'].upper()}]', fg=priority_color))
                             ^^^^^^^^^^^^^^
SyntaxError: f-string: f-string: unmatched '['

```

Please note nested f-string