### PR TITLE
Fix false positive detection of required field validation errors

### DIFF
--- a/src/mxcp/endpoints/loader.py
+++ b/src/mxcp/endpoints/loader.py
@@ -29,10 +29,6 @@ def extract_validation_error(error_msg: str) -> str:
     Returns:
         A concise error message
     """
-    # For required field errors
-    if "'required'" in error_msg:
-        field = error_msg.split("'")[1]
-        return f"Missing required field: {field}"
     
     # For type errors
     if "is not of a type" in error_msg:


### PR DESCRIPTION
The error message simplification logic in `extract_validation_error()` is detecting required field errors by searching for the string `'required'` in error messages. This caused false positives when validation error messages contained the word "required" as part of the schema definition itself, rather than indicating an actual missing required field.

If someone adds an unexpected field, it is reported as missing because required:
```diff
diff --git a/examples/earthquakes/tools/tool.yml b/examples/earthquakes/tools/tool.yml
index bd3a61e..2334f19 100644
--- a/examples/earthquakes/tools/tool.yml
+++ b/examples/earthquakes/tools/tool.yml
@@ -47,6 +47,7 @@ tool:
     openWorldHint: true
   tests:
     - name: filter-mag
+      this: should not be here
       arguments:
         - key: min_magnitude
           value: 5.5
```
```
% mxcp validate     

🔍 Validation Results
   Validated 2 endpoint files
   • 1 passed
   • 1 failed

❌ Failed validation:
  ✗ /Users/bgaidioz/IdeaProjects/mxcp/examples/earthquakes/tools/tool.yml
    Error: Missing required field: this

✅ Passed validation:
  ✓ prompts/prompt.yml

💡 Tip: Fix validation errors to ensure endpoints work correctly
```
With the patch, the generic logic applies.
```
% mxcp validate                         

🔍 Validation Results
   Validated 2 endpoint files
   • 1 passed
   • 1 failed

❌ Failed validation:
  ✗ /Users/bgaidioz/IdeaProjects/mxcp/examples/earthquakes/tools/tool.yml
    Error: Additional properties are not allowed ('this' was unexpected)

✅ Passed validation:
  ✓ prompts/prompt.yml

💡 Tip: Fix validation errors to ensure endpoints work correctly
```
And regarding actual errors due to required fields, with the logic removed, they're reported this way:
```
% mxcp validate     

🔍 Validation Results
   Validated 2 endpoint files
   • 1 passed
   • 1 failed

❌ Failed validation:
  ✗ /Users/bgaidioz/IdeaProjects/mxcp/examples/earthquakes/tools/tool.yml
    Error: 'name' is a required property

✅ Passed validation:
  ✓ prompts/prompt.yml

💡 Tip: Fix validation errors to ensure endpoints work correctly
```