### PR TITLE
Update MCP SDK to v1.12 and explicitly set OAuth resource_server_url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "BUSL-1.1"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.9.0",  # Official MCP Python SDK
+    "mcp~=1.12.0",  # Official MCP Python SDK
     "click>=8.1.7",
     "pyyaml>=6.0.1",
     "jsonschema",

--- a/src/mxcp/server/mcp.py
+++ b/src/mxcp/server/mcp.py
@@ -225,6 +225,7 @@ class RAWMCP:
             
             self.auth_settings = AuthSettings(
                 issuer_url=base_url,
+                resource_server_url=None,
                 client_registration_options=ClientRegistrationOptions(
                     enabled=True,
                     valid_scopes=None,  # Accept any scope
@@ -1426,4 +1427,4 @@ class RAWMCP:
             return JSONResponse(
                 content=metadata,
                 headers={"Content-Type": "application/json"}
-            ) 
+            )


### PR DESCRIPTION
This PR contains two related updates:

**Dependencies:**
- Update MCP SDK from `>=1.9.0` to `~=1.12.0` for better version compatibility and access to latest features

**OAuth Configuration:**
- Explicitly set `resource_server_url=None` in `AuthSettings` (it's a mandatory parameter since `1.10.x`) to clarify that this MXCP server acts as both Authorization Server and Resource Server from the same base URL
- This follows OAuth 2.0 Protected Resource Metadata best practices for combined AS+RS architectures where no separate resource server URL is needed