### PR TITLE
Fix OAuth scope extraction in all provider implementations

### DIFF
--- a/src/mxcp/sdk/auth/providers/atlassian.py
+++ b/src/mxcp/sdk/auth/providers/atlassian.py
@@ -167,7 +167,7 @@ class AtlassianOAuthHandler(ExternalOAuthHandler):
 
         # Extract scopes from token response
         scopes = payload.get("scope", "").split() if payload.get("scope") else []
-        
+
         user_info = ExternalUserInfo(
             id=user_id,
             scopes=scopes,

--- a/src/mxcp/sdk/auth/providers/atlassian.py
+++ b/src/mxcp/sdk/auth/providers/atlassian.py
@@ -165,9 +165,12 @@ class AtlassianOAuthHandler(ExternalOAuthHandler):
         # Don't clean up state here - let handle_callback do it after getting metadata
         logger.info(f"Atlassian OAuth token exchange successful for user: {user_id}")
 
+        # Extract scopes from token response
+        scopes = payload.get("scope", "").split() if payload.get("scope") else []
+        
         user_info = ExternalUserInfo(
             id=user_id,
-            scopes=[],
+            scopes=scopes,
             raw_token=access_token,
             provider="atlassian",
         )

--- a/src/mxcp/sdk/auth/providers/github.py
+++ b/src/mxcp/sdk/auth/providers/github.py
@@ -146,7 +146,7 @@ class GitHubOAuthHandler(ExternalOAuthHandler):
 
         # Extract scopes from token response
         scopes = payload.get("scope", "").split() if payload.get("scope") else []
-        
+
         user_info = ExternalUserInfo(
             id=str(user_id),
             scopes=scopes,

--- a/src/mxcp/sdk/auth/providers/github.py
+++ b/src/mxcp/sdk/auth/providers/github.py
@@ -144,9 +144,12 @@ class GitHubOAuthHandler(ExternalOAuthHandler):
         # Don't clean up state here - let handle_callback do it after getting metadata
         logger.info(f"GitHub OAuth token exchange successful for user: {user_id}")
 
+        # Extract scopes from token response
+        scopes = payload.get("scope", "").split() if payload.get("scope") else []
+        
         user_info = ExternalUserInfo(
             id=str(user_id),
-            scopes=[],
+            scopes=scopes,
             raw_token=access_token,
             provider="github",
         )

--- a/src/mxcp/sdk/auth/providers/google.py
+++ b/src/mxcp/sdk/auth/providers/google.py
@@ -167,7 +167,7 @@ class GoogleOAuthHandler(ExternalOAuthHandler):
 
         # Extract scopes from token response
         scopes = payload.get("scope", "").split() if payload.get("scope") else []
-        
+
         user_info = ExternalUserInfo(
             id=user_id,
             scopes=scopes,

--- a/src/mxcp/sdk/auth/providers/google.py
+++ b/src/mxcp/sdk/auth/providers/google.py
@@ -165,9 +165,12 @@ class GoogleOAuthHandler(ExternalOAuthHandler):
         # Don't clean up state here - let handle_callback do it after getting metadata
         logger.info(f"Google OAuth token exchange successful for user: {user_id}")
 
+        # Extract scopes from token response
+        scopes = payload.get("scope", "").split() if payload.get("scope") else []
+        
         user_info = ExternalUserInfo(
             id=user_id,
-            scopes=[],
+            scopes=scopes,
             raw_token=access_token,
             provider="google",
         )

--- a/src/mxcp/sdk/auth/providers/salesforce.py
+++ b/src/mxcp/sdk/auth/providers/salesforce.py
@@ -159,9 +159,12 @@ class SalesforceOAuthHandler(ExternalOAuthHandler):
         # Don't clean up state here - let handle_callback do it after getting metadata
         logger.info(f"Salesforce OAuth token exchange successful for user: {user_id}")
 
+        # Extract scopes from token response
+        scopes = payload.get("scope", "").split() if payload.get("scope") else []
+        
         user_info = ExternalUserInfo(
             id=user_id,
-            scopes=[],
+            scopes=scopes,
             raw_token=access_token,
             provider="salesforce",
         )

--- a/src/mxcp/sdk/auth/providers/salesforce.py
+++ b/src/mxcp/sdk/auth/providers/salesforce.py
@@ -161,7 +161,7 @@ class SalesforceOAuthHandler(ExternalOAuthHandler):
 
         # Extract scopes from token response
         scopes = payload.get("scope", "").split() if payload.get("scope") else []
-        
+
         user_info = ExternalUserInfo(
             id=user_id,
             scopes=scopes,


### PR DESCRIPTION
## Description
Fix OAuth scope extraction bug where all OAuth providers (Google, GitHub, Atlassian, Salesforce) were hardcoding empty scopes instead of extracting the actual granted scopes from OAuth token responses. This caused "insufficient authentication scopes" errors when accessing external APIs and prevented proper scope-based authorization in MXCP.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [x] Tests pass locally with `uv run pytest`
- [x] Linting passes with `uv run ruff check .`
- [x] Code formatting passes with `uv run black --check .`
- [x] Type checking passes with `uv run mypy .`
- [ ] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [x] Sensitive data handling reviewed (if applicable)
- [x] Policy enforcement implications considered (if applicable)

## Breaking Changes
This is not a breaking change. The fix improves existing functionality by correctly storing OAuth scopes that were previously being lost.

## Additional Notes

### Root Cause
All OAuth provider implementations were creating `ExternalUserInfo` objects with hardcoded empty scopes (`scopes=[]`) instead of extracting the actual scopes from the OAuth token response payload.

### Files Changed
- `src/mxcp/sdk/auth/providers/google.py`
- `src/mxcp/sdk/auth/providers/github.py` 
- `src/mxcp/sdk/auth/providers/atlassian.py`
- `src/mxcp/sdk/auth/providers/salesforce.py`

### Fix Applied
Added scope extraction logic in all providers:
```python
# Extract scopes from token response
scopes = payload.get("scope", "").split() if payload.get("scope") else []
```

### Impact
- OAuth tokens now correctly store granted scopes in the database
- Scope-based authorization will work as intended when configured
- External API calls using user tokens will have proper scope validation
- Consistent behavior across all OAuth providers (matching existing Keycloak implementation)

### Testing Recommendations
1. Verify OAuth authentication flow stores non-empty scopes in database
2. Test scope-based authorization with `required_scopes` configuration
3. Confirm external API calls work with properly scoped tokens