### PR TITLE
Fix undefined result variable in MCP server finally block

### DIFF
--- a/src/mxcp/server/interfaces/server/mcp.py
+++ b/src/mxcp/server/interfaces/server/mcp.py
@@ -1223,6 +1223,7 @@ class RAWMCP:
             start_time = time.time()
             status = "success"
             error_msg = None
+            result = None  # Initialize result to avoid undefined variable in finally block
             policy_info: dict[str, Any] = {
                 "policies_evaluated": [],
                 "policy_decision": None,


### PR DESCRIPTION
## Description
Prevents `UnboundLocalError` when the result variable is accessed in the `finally` block before being defined in the `try` block.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [x] Tests pass locally with `uv run pytest`
- [x] Linting passes with `uv run ruff check .`
- [x] Code formatting passes with `uv run black --check .`
- [x] Type checking passes with `uv run mypy .`
- [ ] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [ ] Sensitive data handling reviewed (if applicable)
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
No.

## Additional Notes
Triggered by a tool call that fails to validate in FastMCP.