### PR TITLE
Fix OAuth redirect URI validation type mismatch

### DIFF
--- a/src/mxcp/sdk/auth/base.py
+++ b/src/mxcp/sdk/auth/base.py
@@ -353,8 +353,6 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
                 else:
                     redirect_uris.append(uri)  # Already an AnyUrl object
 
-            logger.info(f"redirect_uris: {redirect_uris}")
-
             # Create client object
             client_info = OAuthClientInformationFull(
                 client_id=client_id,

--- a/src/mxcp/sdk/auth/base.py
+++ b/src/mxcp/sdk/auth/base.py
@@ -224,6 +224,11 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
                         )
                         # Skip malformed URIs but continue loading the client
 
+                # Skip client if no valid redirect URIs remain
+                if not redirect_uris_any and redirect_uris_str:
+                    logger.error(f"Skipping configured client {client_id}: no valid redirect URIs")
+                    continue
+
                 client = OAuthClientInformationFull(
                     client_id=client_id,
                     client_secret=client_config.get("client_secret"),  # None for public clients

--- a/src/mxcp/sdk/auth/base.py
+++ b/src/mxcp/sdk/auth/base.py
@@ -161,14 +161,14 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
             persisted_clients = await self.persistence.list_clients()
             for client_data in persisted_clients:
                 try:
-                    # Convert string URLs back to AnyHttpUrl objects for OAuthClientInformationFull
+                    # Convert string URLs back to AnyUrl objects for OAuthClientInformationFull
 
                     redirect_uris_pydantic = []
 
                     # Validate each redirect URI individually
                     for uri in client_data.redirect_uris:
                         try:
-                            redirect_uris_pydantic.append(AnyHttpUrl(uri))
+                            redirect_uris_pydantic.append(AnyUrl(uri))
                         except ValidationError as ve:
                             logger.warning(
                                 f"Skipping malformed redirect URI for client {client_data.client_id}: {uri} - {ve}"
@@ -185,9 +185,7 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
                     client = OAuthClientInformationFull(
                         client_id=client_data.client_id,
                         client_secret=client_data.client_secret,
-                        redirect_uris=cast(
-                            list[AnyUrl], redirect_uris_pydantic
-                        ),  # Use validated URIs
+                        redirect_uris=redirect_uris_pydantic,
                         grant_types=cast(
                             list[Literal["authorization_code", "refresh_token"]],
                             client_data.grant_types,
@@ -214,7 +212,13 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
             for client_config in clients:
                 client_id = client_config["client_id"]
                 redirect_uris_str = client_config.get("redirect_uris", [])
-                redirect_uris_any = [cast(AnyUrl, uri) for uri in (redirect_uris_str or [])]
+                # Convert string URIs to AnyUrl objects
+                redirect_uris_any = []
+                for uri in redirect_uris_str or []:
+                    if isinstance(uri, str):
+                        redirect_uris_any.append(AnyUrl(uri))
+                    else:
+                        redirect_uris_any.append(uri)  # Already an AnyUrl object
 
                 client = OAuthClientInformationFull(
                     client_id=client_id,
@@ -253,14 +257,14 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
                     persisted_client = await self.persistence.load_client(client_id)
                     if persisted_client:
                         # Load into memory cache
-                        # Convert string URLs back to AnyHttpUrl objects for OAuthClientInformationFull
+                        # Convert string URLs back to AnyUrl objects for OAuthClientInformationFull
 
                         redirect_uris_pydantic = []
 
                         # Validate each redirect URI individually
                         for uri in persisted_client.redirect_uris:
                             try:
-                                redirect_uris_pydantic.append(AnyHttpUrl(uri))
+                                redirect_uris_pydantic.append(AnyUrl(uri))
                             except ValidationError as ve:
                                 logger.warning(
                                     f"Skipping malformed redirect URI for client {client_id}: {uri} - {ve}"
@@ -275,9 +279,7 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
                         client = OAuthClientInformationFull(
                             client_id=persisted_client.client_id,
                             client_secret=persisted_client.client_secret,
-                            redirect_uris=cast(
-                                list[AnyUrl], redirect_uris_pydantic
-                            ),  # Use validated URIs
+                            redirect_uris=redirect_uris_pydantic,
                             grant_types=cast(
                                 list[Literal["authorization_code", "refresh_token"]],
                                 persisted_client.grant_types,
@@ -307,13 +309,13 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
             # Store in persistence if available
             if self.persistence:
                 try:
-                    # Convert Pydantic AnyHttpUrl objects to strings for JSON serialization
+                    # Convert Pydantic AnyUrl objects to strings for JSON serialization
                     redirect_uris_str = [str(uri) for uri in client_info.redirect_uris]
 
                     persisted_client = PersistedClient(
                         client_id=client_info.client_id,
                         client_secret=client_info.client_secret,
-                        redirect_uris=redirect_uris_str,  # Convert AnyHttpUrl to strings
+                        redirect_uris=redirect_uris_str,  # Convert AnyUrl to strings
                         grant_types=cast(list[str], client_info.grant_types),
                         response_types=cast(list[str], client_info.response_types),
                         scope=client_info.scope or "",
@@ -337,11 +339,21 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
             client_secret = secrets.token_urlsafe(64)
 
             # Extract and validate metadata
-            redirect_uris = client_metadata.get("redirect_uris", [])
+            redirect_uris_raw = client_metadata.get("redirect_uris", [])
             grant_types = client_metadata.get("grant_types", ["authorization_code"])
             response_types = client_metadata.get("response_types", ["code"])
             scope = client_metadata.get("scope", "mxcp:access")
             client_name = client_metadata.get("client_name", "MCP Client")
+
+            # Convert redirect URIs to AnyUrl objects as required by OAuthClientInformationFull
+            redirect_uris = []
+            for uri in redirect_uris_raw:
+                if isinstance(uri, str):
+                    redirect_uris.append(AnyUrl(uri))
+                else:
+                    redirect_uris.append(uri)  # Already an AnyUrl object
+
+            logger.info(f"redirect_uris: {redirect_uris}")
 
             # Create client object
             client_info = OAuthClientInformationFull(

--- a/src/mxcp/sdk/auth/base.py
+++ b/src/mxcp/sdk/auth/base.py
@@ -212,13 +212,7 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
             for client_config in clients:
                 client_id = client_config["client_id"]
                 redirect_uris_str = client_config.get("redirect_uris", [])
-                # Convert string URIs to AnyUrl objects
-                redirect_uris_any = []
-                for uri in redirect_uris_str or []:
-                    if isinstance(uri, str):
-                        redirect_uris_any.append(AnyUrl(uri))
-                    else:
-                        redirect_uris_any.append(uri)  # Already an AnyUrl object
+                redirect_uris_any = [AnyUrl(uri) for uri in redirect_uris_str or []]
 
                 client = OAuthClientInformationFull(
                     client_id=client_id,
@@ -345,13 +339,7 @@ class GeneralOAuthAuthorizationServer(OAuthAuthorizationServerProvider[Any, Any,
             scope = client_metadata.get("scope", "mxcp:access")
             client_name = client_metadata.get("client_name", "MCP Client")
 
-            # Convert redirect URIs to AnyUrl objects as required by OAuthClientInformationFull
-            redirect_uris = []
-            for uri in redirect_uris_raw:
-                if isinstance(uri, str):
-                    redirect_uris.append(AnyUrl(uri))
-                else:
-                    redirect_uris.append(uri)  # Already an AnyUrl object
+            redirect_uris = [AnyUrl(uri) for uri in redirect_uris_raw]
 
             # Create client object
             client_info = OAuthClientInformationFull(

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "mxcp"
-version = "0.6.1"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "mxcp"
-version = "0.5.1"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Description
### Bug
* when loading OAuth client info from our DB, we pass their redirect URLs to FastMCP, using `AnyHttpUrl` objects. That is correct because FastMCP expects `AnyUrl`, and `AnyHttpUrl` is a subclass.
* when FastMCP compares the redirect URLs it got from us to what the client advertises, it turns the client's URL into `AnyUrl`, and compares it to what we had passed.
* But `AnyUrl(<url>)` isn't equal to `AnyHttpUrl(<url>)` even for the same URL.
  ```python
  from pydantic import AnyHttpUrl, AnyUrl
  from typing import cast
  
  httpUrl = AnyHttpUrl('http://redirect.com')
  url = AnyUrl('http://redirect.com')
  
  print(httpUrl == url) # False
  print(cast(AnyUrl, httpUrl) == url) # False
  ```
* The comparison fails, FastMCP concludes URLs don't match, and the client gets an error ("Redirect URI not registered for client").

### Fix
Stores `AnyUrl` objects in the authentication info passed to FastMCP.
* in the code path where we load from persistence, changed to`AnyUrl`,
* in the code path where we load from config, kept `AnyUrl` but also ignore validation failures (like it's already done in the persistence case).
## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [x] Tests pass locally with `uv run pytest`
- [x] Linting passes with `uv run ruff check .`
- [x] Code formatting passes with `uv run black --check .`
- [x] Type checking passes with `uv run mypy .`
- [ ] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [ ] Sensitive data handling reviewed (if applicable)
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
No.

## Additional Notes