### PR TITLE
Add OAuth user context caching

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1185,6 +1185,42 @@ projects:
             # ... other GitHub config
 ```
 
+## User Context Caching
+
+MXCP caches user context information to improve performance and reduce load on OAuth providers. When a user is authenticated, their user information (username, email, provider details) is cached to avoid making API calls to the OAuth provider on every tool execution.
+
+### Cache TTL Configuration
+
+You can configure the cache duration using the `cache_ttl` setting:
+
+```yaml
+projects:
+  my_project:
+    profiles:
+      dev:
+        auth:
+          provider: github
+          cache_ttl: 300  # Cache user context for 5 minutes (default: 300 seconds)
+          
+          clients:
+            - client_id: "${CLIENT_ID}"
+              # ... client config
+```
+
+**Configuration Options:**
+
+- `cache_ttl`: Cache duration in seconds for user context information
+  - **Default**: 300 seconds (5 minutes)
+  - **Purpose**: Reduces API calls to OAuth providers, improving performance and avoiding rate limits
+  - **Range**: Any positive integer (recommended: 60-1800 seconds)
+
+**Security Considerations:**
+
+- Cached user context expires automatically after the TTL period
+- User information is cached in memory only (not persisted to disk)
+- Cache is cleared when the server restarts
+- Shorter TTL values provide more up-to-date user information but increase API calls
+
 ## Authorization Configuration
 
 MXCP supports configurable scope-based authorization to control access to your endpoints and tools. You can specify which OAuth scopes are required for accessing your server's resources.

--- a/src/mxcp/sdk/auth/_types.py
+++ b/src/mxcp/sdk/auth/_types.py
@@ -133,6 +133,7 @@ class AuthConfig(TypedDict, total=False):
     """
 
     provider: Literal["none", "github", "atlassian", "salesforce", "keycloak", "google"] | None
+    cache_ttl: int | None  # Cache TTL in seconds for user context caching
     clients: list[OAuthClientConfig] | None  # Pre-configured OAuth clients
     authorization: AuthorizationConfig | None  # Authorization policies
     persistence: AuthPersistenceConfig | None  # Token/client persistence

--- a/src/mxcp/server/core/auth/helpers.py
+++ b/src/mxcp/server/core/auth/helpers.py
@@ -29,6 +29,7 @@ def translate_auth_config(user_auth_config: UserAuthConfig) -> AuthConfig:
     """
     return {
         "provider": user_auth_config.get("provider"),
+        "cache_ttl": user_auth_config.get("cache_ttl"),
         "clients": user_auth_config.get("clients"),
         "authorization": user_auth_config.get("authorization"),
         "persistence": user_auth_config.get("persistence"),

--- a/src/mxcp/server/core/config/_types.py
+++ b/src/mxcp/server/core/config/_types.py
@@ -177,6 +177,7 @@ class UserAuthorizationConfig(TypedDict, total=False):
 
 class UserAuthConfig(TypedDict, total=False):
     provider: Literal["none", "github", "atlassian", "salesforce", "keycloak", "google"] | None
+    cache_ttl: int | None  # Cache TTL in seconds for user context caching (default: 300)
     clients: list[UserOAuthClientConfig] | None
     github: UserGitHubAuthConfig | None
     atlassian: UserAtlassianAuthConfig | None

--- a/src/mxcp/server/interfaces/server/mcp.py
+++ b/src/mxcp/server/interfaces/server/mcp.py
@@ -482,8 +482,16 @@ class RAWMCP:
 
         self.mcp = FastMCP(**fastmcp_kwargs)
 
-        # Initialize authentication middleware
-        self.auth_middleware = AuthenticationMiddleware(self.oauth_handler, self.oauth_server)
+        # Initialize authentication middleware with configurable cache TTL
+        auth_config = self.active_profile.get("auth", {})
+        cache_ttl = auth_config.get("cache_ttl")
+        if cache_ttl is not None:
+            self.auth_middleware = AuthenticationMiddleware(
+                self.oauth_handler, self.oauth_server, cache_ttl=cache_ttl
+            )
+        else:
+            # Use default cache TTL
+            self.auth_middleware = AuthenticationMiddleware(self.oauth_handler, self.oauth_server)
 
         # Register OAuth routes if enabled
         if self.oauth_handler and self.oauth_server:


### PR DESCRIPTION
## Description
Each tool invocation fetches the user context to pass as a parameter. This currently triggers a call to the AS on every request. In this changeset, a five-minute cache is added to minimize remote AS calls.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [x] Tests pass locally with `uv run pytest`
- [x] Linting passes with `uv run ruff check .`
- [x] Code formatting passes with `uv run black --check .`
- [x] Type checking passes with `uv run mypy .`
- [ ] Added tests for new functionality (if applicable)
- [x] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [ ] Sensitive data handling reviewed (if applicable)
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
No.

## Additional Notes
Here's the log when calling a tool after more than five minutes and the keycloak access token has expired in the meantime.
1. The cached entry is removed because expired.
2. A call to keycloak is issued to read the user context again.
3. The MCP tool is called with a recent user context.
```
INFO:mcp.server.lowlevel.server:Processing request of type CallToolRequest
DEBUG:mcp.server.lowlevel.server:Dispatching request of type CallToolRequest
DEBUG:mxcp.sdk.auth.middleware:Access token found in request context
DEBUG:mxcp.sdk.auth.middleware:Token validated successfully for client: 8434ecf2-6827-4ea3-8936-59a2b0809d77
DEBUG:mxcp.sdk.auth.middleware:External token mapping found
DEBUG:mxcp.sdk.auth.middleware:⏰ Cache EXPIRED - removed entry for token mcp_1866ad83e8bdd8ac...
DEBUG:mxcp.sdk.auth.middleware:🔄 Cache MISS - calling KeycloakOAuthHandler.get_user_context() - Provider API call #384
...
...
...
DEBUG:httpcore.http11:receive_response_headers.started request=<Request [b'GET']>
DEBUG:httpcore.http11:receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'content-length', b'196'), (b'Cache-Control', b'no-cache'), (b'Content-Type', b'application/json'), (b'Referrer-Policy', b'no-referrer'), (b'Strict-Transport-Security', b'max-age=31536000; includeSubDomains'), (b'X-Content-Type-Options', b'nosniff'), (b'X-Frame-Options', b'SAMEORIGIN')])
INFO:httpx:HTTP Request: GET http://localhost:8080/realms/demo/protocol/openid-connect/userinfo "HTTP/1.1 200 OK"
...
...
...
DEBUG:mxcp.sdk.auth.middleware:💾 Cache STORE - cached user context for token mcp_1866ad83e8bdd8ac... (TTL: 300s)
DEBUG:mxcp.sdk.auth.middleware:Successfully retrieved user context for ben (provider: keycloak)
DEBUG:mxcp.sdk.auth.middleware:Executing _body for authenticated user (provider: keycloak)
INFO:mxcp.server.interfaces.server.mcp:Calling tool get_user_info with: {}
INFO:mxcp.server.interfaces.server.mcp:Authenticated user: ben (provider: keycloak)
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds in-memory user context caching with configurable TTL and integrates it into server config and docs.
> 
> - **Authentication Middleware (`src/mxcp/sdk/auth/middleware.py`)**:
>   - Add in-memory user context cache with default TTL (`300s`) and async locks/cleanup.
>   - Serve cached `UserContext` by external token; populate `external_token` via `replace` to avoid races.
>   - New constructor param `cache_ttl`; schedule periodic cleanup of expired entries.
> - **Config Wiring**:
>   - SDK `AuthConfig` adds `cache_ttl` (`src/mxcp/sdk/auth/_types.py`).
>   - User config supports `auth.cache_ttl` (`src/mxcp/server/core/config/_types.py`).
>   - Translate and pass `cache_ttl` from user config (`src/mxcp/server/core/auth/helpers.py`).
>   - Initialize `AuthenticationMiddleware` with `cache_ttl` from active profile (`src/mxcp/server/interfaces/server/mcp.py`).
> - **Docs (`docs/guides/authentication.md`)**:
>   - New "User Context Caching" section with `cache_ttl` usage, defaults, range, and security notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d822c32d8648d54dda73fa1ea650eb9b05aab3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->