### PR TITLE
Added --chown to COPY in docker/README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -38,7 +38,7 @@ FROM ghcr.io/raw-labs/mxcp:latest
 COPY --chown=mxcp:mxcp . /mxcp-site/
 
 # Install additional Python dependencies (optional)
-COPY requirements.txt /tmp/
+COPY --chown=mxcp:mxcp requirements.txt /tmp/
 RUN /mxcp-site/.venv/bin/pip install -r /tmp/requirements.txt && \
     rm /tmp/requirements.txt
 ```


### PR DESCRIPTION
## Description
Fixed docker/README.md because the instructions don't work due to access rights (`rm` fails).

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [ ] Tests pass locally with `uv run pytest`
- [ ] Linting passes with `uv run ruff check .`
- [ ] Code formatting passes with `uv run black --check .`
- [ ] Type checking passes with `uv run mypy .`
- [ ] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [ ] This change does not introduce security vulnerabilities
- [ ] Sensitive data handling reviewed (if applicable)
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
If this is a breaking change, describe what users need to do to migrate:

## Additional Notes
Other option just to shorten a bit the lines to copy/paste.

Embed (in the parent image):
```Dockerfile
WORKDIR /mxcp-site
```
One can use the current dir.
```Dockerfile
COPY --chown=mxcp:mxcp requirements.txt .
RUN .venv/bin/pip install -r requirements.txt && rm requirements.txt
```
Apparently: "Docker best practice: copy into the workdir unless there’s a reason not to."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set mxcp ownership on `requirements.txt` COPY in `docker/README.md` Dockerfile example to prevent permission issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 731d093603581f273ec20eda66e24c715ad8c8c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->