### PR TITLE
Fix provider scope fallback for whitespace scopes

### DIFF
--- a/src/mxcp/sdk/auth/providers/atlassian.py
+++ b/src/mxcp/sdk/auth/providers/atlassian.py
@@ -16,6 +16,7 @@ from mxcp.sdk.models import SdkBaseModel
 
 from ..contracts import GrantResult, ProviderAdapter, ProviderError, UserInfo
 from ..models import AtlassianAuthConfigModel
+from .scope_utils import normalize_granted_scopes
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ class AtlassianProviderAdapter(ProviderAdapter):
         # - The token endpoint `scope` field is OPTIONAL. When absent, it generally means
         #   the granted scopes are identical to those requested at the authorize step.
         # - Do NOT interpret missing `scope` as “zero scopes”.
-        granted_scopes = token.scope.split() if token.scope else list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         token_type = token.token_type if token.token_type is not None else "Bearer"
 
         return GrantResult(
@@ -168,7 +169,7 @@ class AtlassianProviderAdapter(ProviderAdapter):
             raise ProviderError("invalid_grant", "No access_token in refresh response", 400)
 
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
-        granted_scopes = (token.scope.split() if token.scope else []) or list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         token_type = token.token_type if token.token_type is not None else "Bearer"
 
         return GrantResult(

--- a/src/mxcp/sdk/auth/providers/github.py
+++ b/src/mxcp/sdk/auth/providers/github.py
@@ -16,6 +16,7 @@ from mxcp.sdk.models import SdkBaseModel
 
 from ..contracts import GrantResult, ProviderAdapter, ProviderError, UserInfo
 from ..models import GitHubAuthConfigModel
+from .scope_utils import normalize_granted_scopes
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +134,7 @@ class GitHubProviderAdapter(ProviderAdapter):
             raise ProviderError("invalid_grant", "No access_token in response", status_code=400)
 
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
-        granted_scopes = token.scope.split(",") if token.scope else list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes, separator=",")
         token_type = token.token_type if token.token_type is not None else "Bearer"
 
         return GrantResult(
@@ -161,7 +162,7 @@ class GitHubProviderAdapter(ProviderAdapter):
         if not access_token:
             raise ProviderError("invalid_grant", "No access_token in refresh response", 400)
 
-        granted_scopes = (token.scope.split(",") if token.scope else []) or list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes, separator=",")
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
         token_type = token.token_type if token.token_type is not None else "Bearer"
 

--- a/src/mxcp/sdk/auth/providers/google.py
+++ b/src/mxcp/sdk/auth/providers/google.py
@@ -16,6 +16,7 @@ from mxcp.sdk.models import SdkBaseModel
 
 from ..contracts import GrantResult, ProviderAdapter, ProviderError, UserInfo
 from ..models import GoogleAuthConfigModel
+from .scope_utils import normalize_granted_scopes
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +148,7 @@ class GoogleProviderAdapter(ProviderAdapter):
         # In issuer-mode, the `scopes` argument is expected to reflect the provider
         # scopes used at /authorize (from configuration), not scopes supplied by the
         # OAuth client.
-        granted_scopes = token.scope.split() if token.scope else list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         return GrantResult(
             access_token=access_token,
             refresh_token=refresh_token,
@@ -173,7 +174,7 @@ class GoogleProviderAdapter(ProviderAdapter):
         if not access_token:
             raise ProviderError("invalid_grant", "No access_token in refresh response", 400)
 
-        granted_scopes = (token.scope.split() if token.scope else []) or list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
 
         token_type = token.token_type if token.token_type is not None else "Bearer"

--- a/src/mxcp/sdk/auth/providers/keycloak.py
+++ b/src/mxcp/sdk/auth/providers/keycloak.py
@@ -16,6 +16,7 @@ from mxcp.sdk.models import SdkBaseModel
 
 from ..contracts import GrantResult, ProviderAdapter, ProviderError, UserInfo
 from ..models import KeycloakAuthConfigModel
+from .scope_utils import normalize_granted_scopes
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +130,7 @@ class KeycloakProviderAdapter(ProviderAdapter):
             raise ProviderError("invalid_grant", "No access_token in response", status_code=400)
 
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
-        granted_scopes = token.scope.split() if token.scope else list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         token_type = token.token_type if token.token_type is not None else "Bearer"
 
         return GrantResult(
@@ -156,7 +157,7 @@ class KeycloakProviderAdapter(ProviderAdapter):
         if not access_token:
             raise ProviderError("invalid_grant", "No access_token in refresh response", 400)
 
-        granted_scopes = (token.scope.split() if token.scope else []) or list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
         token_type = token.token_type if token.token_type is not None else "Bearer"
 

--- a/src/mxcp/sdk/auth/providers/oidc.py
+++ b/src/mxcp/sdk/auth/providers/oidc.py
@@ -20,6 +20,7 @@ from mxcp.sdk.models import SdkBaseModel
 
 from ..contracts import GrantResult, ProviderAdapter, ProviderError, UserInfo
 from ..models import OIDCAuthConfigModel
+from .scope_utils import normalize_granted_scopes
 
 logger = logging.getLogger(__name__)
 
@@ -290,7 +291,7 @@ class OIDCProviderAdapter(ProviderAdapter):
             raise ProviderError("invalid_grant", "No access_token in response", status_code=400)
 
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
-        granted_scopes = token.scope.split() if token.scope else list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         token_type = token.token_type if token.token_type is not None else "Bearer"
 
         return GrantResult(
@@ -319,7 +320,7 @@ class OIDCProviderAdapter(ProviderAdapter):
         if not access_token:
             raise ProviderError("invalid_grant", "No access_token in refresh response", 400)
 
-        granted_scopes = (token.scope.split() if token.scope else []) or list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
         token_type = token.token_type if token.token_type is not None else "Bearer"
 

--- a/src/mxcp/sdk/auth/providers/salesforce.py
+++ b/src/mxcp/sdk/auth/providers/salesforce.py
@@ -16,6 +16,7 @@ from mxcp.sdk.models import SdkBaseModel
 
 from ..contracts import GrantResult, ProviderAdapter, ProviderError, UserInfo
 from ..models import SalesforceAuthConfigModel
+from .scope_utils import normalize_granted_scopes
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ class SalesforceProviderAdapter(ProviderAdapter):
             raise ProviderError("invalid_grant", "No access_token in response", status_code=400)
 
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
-        granted_scopes = token.scope.split() if token.scope else list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         token_type = token.token_type if token.token_type is not None else "Bearer"
 
         return GrantResult(
@@ -149,7 +150,7 @@ class SalesforceProviderAdapter(ProviderAdapter):
         if not access_token:
             raise ProviderError("invalid_grant", "No access_token in refresh response", 400)
 
-        granted_scopes = (token.scope.split() if token.scope else []) or list(scopes)
+        granted_scopes = normalize_granted_scopes(token.scope, scopes)
         expires_at = time.time() + float(expires_in) if expires_in is not None else None
         token_type = token.token_type if token.token_type is not None else "Bearer"
 

--- a/src/mxcp/sdk/auth/providers/scope_utils.py
+++ b/src/mxcp/sdk/auth/providers/scope_utils.py
@@ -1,0 +1,23 @@
+"""Scope normalization helpers for provider adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def normalize_granted_scopes(
+    scope_str: str | None,
+    requested_scopes: Sequence[str],
+    *,
+    separator: str | None = None,
+) -> list[str]:
+    """Normalize provider scope response and fall back to requested scopes.
+
+    Treat whitespace-only scope strings as missing. For providers that return
+    comma-separated scopes, pass `separator=","` to preserve existing behavior.
+    """
+    if not scope_str or not scope_str.strip():
+        return list(requested_scopes)
+    if separator is None:
+        return scope_str.split()
+    return scope_str.split(separator)

--- a/tests/sdk/auth/test_provider_adapter_contract.py
+++ b/tests/sdk/auth/test_provider_adapter_contract.py
@@ -20,15 +20,18 @@ from mxcp.sdk.auth.models import (
     GitHubAuthConfigModel,
     GoogleAuthConfigModel,
     KeycloakAuthConfigModel,
+    OIDCAuthConfigModel,
     SalesforceAuthConfigModel,
 )
 from mxcp.sdk.auth.providers.atlassian import AtlassianProviderAdapter
 from mxcp.sdk.auth.providers.github import GitHubProviderAdapter
 from mxcp.sdk.auth.providers.google import GoogleProviderAdapter
 from mxcp.sdk.auth.providers.keycloak import KeycloakProviderAdapter
+from mxcp.sdk.auth.providers.oidc import OIDCProviderAdapter
 from mxcp.sdk.auth.providers.salesforce import SalesforceProviderAdapter
 from tests.sdk.auth.provider_adapter_testkit import (
     FakeAsyncHttpClient,
+    FakeResponse,
     FakeResponseJsonError,
     patch_http_client,
 )
@@ -40,6 +43,12 @@ class _ProviderCase:
     adapter_factory: Callable[[], object]
     create_client_path: str
     callback_path: str
+    prepare: Callable[[object], None] | None = None
+
+
+def _prepare_oidc(adapter: OIDCProviderAdapter) -> None:
+    adapter.auth_url = "https://idp.example.com/authorize"
+    adapter.token_url = "https://idp.example.com/token"
 
 
 def _cases() -> list[_ProviderCase]:
@@ -105,6 +114,21 @@ def _cases() -> list[_ProviderCase]:
             callback_path="/keycloak/callback",
         ),
         _ProviderCase(
+            name="oidc",
+            adapter_factory=lambda: OIDCProviderAdapter(
+                OIDCAuthConfigModel(
+                    config_url="https://idp.example.com/.well-known/openid-configuration",
+                    client_id="cid",
+                    client_secret="secret",
+                    scope="openid profile",
+                    callback_path="/oidc/callback",
+                )
+            ),
+            create_client_path="mxcp.sdk.auth.providers.oidc.create_mcp_http_client",
+            callback_path="/oidc/callback",
+            prepare=_prepare_oidc,
+        ),
+        _ProviderCase(
             name="salesforce",
             adapter_factory=lambda: SalesforceProviderAdapter(
                 SalesforceAuthConfigModel(
@@ -122,15 +146,22 @@ def _cases() -> list[_ProviderCase]:
     ]
 
 
+def _prepare_adapter(case: _ProviderCase, adapter: object) -> None:
+    if case.prepare:
+        case.prepare(adapter)
+
+
 @pytest.mark.parametrize("case", _cases(), ids=lambda c: c.name)
 def test_callback_path_property_matches_config(case: _ProviderCase) -> None:
     adapter = case.adapter_factory()
+    _prepare_adapter(case, adapter)
     assert getattr(adapter, "callback_path") == case.callback_path
 
 
 @pytest.mark.parametrize("case", _cases(), ids=lambda c: c.name)
 def test_build_authorize_url_includes_boundary_params(case: _ProviderCase) -> None:
     adapter = case.adapter_factory()
+    _prepare_adapter(case, adapter)
     url = adapter.build_authorize_url(
         redirect_uri="https://server/callback",
         state="STATE",
@@ -154,6 +185,7 @@ async def test_exchange_code_invalid_json_raises_provider_error(
     patch_http_client(monkeypatch, case.create_client_path, fake_client)
 
     adapter = case.adapter_factory()
+    _prepare_adapter(case, adapter)
     with pytest.raises(ProviderError):
         await adapter.exchange_code(
             code="code",
@@ -161,3 +193,48 @@ async def test_exchange_code_invalid_json_raises_provider_error(
             code_verifier=None,
             scopes=["s1"],
         )
+
+
+@pytest.mark.parametrize("case", _cases(), ids=lambda c: c.name)
+@pytest.mark.asyncio
+async def test_exchange_code_whitespace_scope_falls_back(
+    case: _ProviderCase, monkeypatch: MonkeyPatch
+) -> None:
+    fake_client = FakeAsyncHttpClient(
+        post_response=FakeResponse(
+            200,
+            {
+                "access_token": "at",
+                "refresh_token": "rt",
+                "expires_in": 3600,
+                "scope": "   ",
+            },
+        )
+    )
+    patch_http_client(monkeypatch, case.create_client_path, fake_client)
+
+    adapter = case.adapter_factory()
+    _prepare_adapter(case, adapter)
+    grant = await adapter.exchange_code(
+        code="code",
+        redirect_uri="https://server/callback",
+        code_verifier=None,
+        scopes=["s1", "s2"],
+    )
+    assert grant.provider_scopes_granted == ["s1", "s2"]
+
+
+@pytest.mark.parametrize("case", _cases(), ids=lambda c: c.name)
+@pytest.mark.asyncio
+async def test_refresh_token_whitespace_scope_falls_back(
+    case: _ProviderCase, monkeypatch: MonkeyPatch
+) -> None:
+    fake_client = FakeAsyncHttpClient(
+        post_response=FakeResponse(200, {"access_token": "new-at", "scope": "   "})
+    )
+    patch_http_client(monkeypatch, case.create_client_path, fake_client)
+
+    adapter = case.adapter_factory()
+    _prepare_adapter(case, adapter)
+    grant = await adapter.refresh_token(refresh_token="rt", scopes=["s1", "s2"])
+    assert grant.provider_scopes_granted == ["s1", "s2"]


### PR DESCRIPTION
## Description
Normalize provider token scope handling so whitespace-only scope strings fall back to requested provider scopes, and add contract tests covering this behavior across adapters (including OIDC).

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [ ] Tests pass locally with `uv run pytest`
- [ ] Linting passes with `uv run ruff check .`
- [ ] Code formatting passes with `uv run black --check .`
- [ ] Type checking passes with `uv run mypy .`
- [x] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [ ] Sensitive data handling reviewed (if applicable)
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
None.

## Additional Notes
- Ran `uv run pytest tests/sdk/auth/test_provider_adapter_contract.py`.
- `./check-all.sh` failed due to existing mypy errors in `src/mxcp/sdk/validator/converters.py` (unrelated to this change).
