### PR TITLE
Fix provider HTTP client scope handling

### DIFF
--- a/src/mxcp/sdk/auth/providers/atlassian.py
+++ b/src/mxcp/sdk/auth/providers/atlassian.py
@@ -235,54 +235,54 @@ class AtlassianProviderAdapter(ProviderAdapter):
                     status_code=503,
                 ) from exc
 
-        if resp.status_code != 200:
-            logger.warning(
-                "Atlassian /me endpoint returned non-200",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Atlassian userinfo request failed",
-                status_code=resp.status_code,
-            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Atlassian /me endpoint returned non-200",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Atlassian userinfo request failed",
+                    status_code=resp.status_code,
+                )
 
-        try:
-            payload = resp.json()
-        except Exception as exc:
-            logger.warning(
-                "Atlassian /me endpoint returned invalid JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Atlassian userinfo response was invalid",
-                status_code=resp.status_code,
-            ) from exc
+            try:
+                payload = resp.json()
+            except Exception as exc:
+                logger.warning(
+                    "Atlassian /me endpoint returned invalid JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Atlassian userinfo response was invalid",
+                    status_code=resp.status_code,
+                ) from exc
 
-        if not isinstance(payload, dict):
-            logger.warning(
-                "Atlassian /me endpoint returned non-object JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Atlassian userinfo response was invalid",
-                status_code=resp.status_code,
-            )
+            if not isinstance(payload, dict):
+                logger.warning(
+                    "Atlassian /me endpoint returned non-object JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Atlassian userinfo response was invalid",
+                    status_code=resp.status_code,
+                )
 
-        return payload
+            return payload
 
     async def _request_token(
         self,
@@ -320,7 +320,7 @@ class AtlassianProviderAdapter(ProviderAdapter):
                     "Atlassian token request failed",
                     status_code=503,
                 ) from exc
-        return self._parse_token_response(resp, context=context)
+            return self._parse_token_response(resp, context=context)
 
     def _parse_token_response(self, resp: Any, *, context: str) -> _AtlassianTokenResponse:
         if resp.status_code != 200:

--- a/src/mxcp/sdk/auth/providers/github.py
+++ b/src/mxcp/sdk/auth/providers/github.py
@@ -235,53 +235,53 @@ class GitHubProviderAdapter(ProviderAdapter):
                     status_code=503,
                 ) from exc
 
-        if resp.status_code != 200:
-            logger.warning(
-                "GitHub user endpoint returned non-200",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "user",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "GitHub userinfo request failed",
-                status_code=resp.status_code,
-            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "GitHub user endpoint returned non-200",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "user",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "GitHub userinfo request failed",
+                    status_code=resp.status_code,
+                )
 
-        try:
-            payload = resp.json()
-        except Exception as exc:
-            logger.warning(
-                "GitHub user endpoint returned invalid JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "user",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "GitHub userinfo response was invalid",
-                status_code=resp.status_code,
-            ) from exc
+            try:
+                payload = resp.json()
+            except Exception as exc:
+                logger.warning(
+                    "GitHub user endpoint returned invalid JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "user",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "GitHub userinfo response was invalid",
+                    status_code=resp.status_code,
+                ) from exc
 
-        if not isinstance(payload, dict):
-            logger.warning(
-                "GitHub user endpoint returned non-object JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "user",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "GitHub userinfo response was invalid",
-                status_code=resp.status_code,
-            )
-        return payload
+            if not isinstance(payload, dict):
+                logger.warning(
+                    "GitHub user endpoint returned non-object JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "user",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "GitHub userinfo response was invalid",
+                    status_code=resp.status_code,
+                )
+            return payload
 
     async def _fetch_user_email(self, token: str) -> str | None:
         async with create_mcp_http_client() as client:
@@ -304,51 +304,51 @@ class GitHubProviderAdapter(ProviderAdapter):
                 )
                 return None
 
-        if resp.status_code != 200:
-            logger.warning(
-                "GitHub user emails endpoint returned non-200",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "user_emails",
-                    "status_code": resp.status_code,
-                },
-            )
-            return None
+            if resp.status_code != 200:
+                logger.warning(
+                    "GitHub user emails endpoint returned non-200",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "user_emails",
+                        "status_code": resp.status_code,
+                    },
+                )
+                return None
 
-        try:
-            payload = resp.json()
-        except Exception:
-            logger.warning(
-                "GitHub user emails response was not valid JSON",
-                extra={"provider": self.provider_name, "endpoint": "user_emails"},
-            )
-            return None
-
-        if not isinstance(payload, list):
-            logger.warning(
-                "GitHub user emails response was not a list",
-                extra={"provider": self.provider_name, "endpoint": "user_emails"},
-            )
-            return None
-
-        entries: list[_GitHubEmailEntry] = []
-        for item in payload:
             try:
-                entries.append(_GitHubEmailEntry.model_validate(item))
-            except ValidationError:
-                continue
+                payload = resp.json()
+            except Exception:
+                logger.warning(
+                    "GitHub user emails response was not valid JSON",
+                    extra={"provider": self.provider_name, "endpoint": "user_emails"},
+                )
+                return None
 
-        for entry in entries:
-            if entry.primary and entry.verified and entry.email:
-                return entry.email
-        for entry in entries:
-            if entry.verified and entry.email:
-                return entry.email
-        for entry in entries:
-            if entry.email:
-                return entry.email
+            if not isinstance(payload, list):
+                logger.warning(
+                    "GitHub user emails response was not a list",
+                    extra={"provider": self.provider_name, "endpoint": "user_emails"},
+                )
+                return None
 
-        return None
+            entries: list[_GitHubEmailEntry] = []
+            for item in payload:
+                try:
+                    entries.append(_GitHubEmailEntry.model_validate(item))
+                except ValidationError:
+                    continue
+
+            for entry in entries:
+                if entry.primary and entry.verified and entry.email:
+                    return entry.email
+            for entry in entries:
+                if entry.verified and entry.email:
+                    return entry.email
+            for entry in entries:
+                if entry.email:
+                    return entry.email
+
+            return None
 
     async def _request_token(
         self,
@@ -381,7 +381,7 @@ class GitHubProviderAdapter(ProviderAdapter):
                     "GitHub token request failed",
                     status_code=503,
                 ) from exc
-        return self._parse_token_response(resp, context=context)
+            return self._parse_token_response(resp, context=context)
 
     def _parse_token_response(self, resp: Any, *, context: str) -> _GitHubTokenResponse:
         if resp.status_code != 200:

--- a/src/mxcp/sdk/auth/providers/google.py
+++ b/src/mxcp/sdk/auth/providers/google.py
@@ -241,53 +241,53 @@ class GoogleProviderAdapter(ProviderAdapter):
                     status_code=503,
                 ) from exc
 
-        if resp.status_code != 200:
-            logger.warning(
-                "Google userinfo endpoint returned non-200",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Google userinfo request failed",
-                status_code=resp.status_code,
-            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Google userinfo endpoint returned non-200",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Google userinfo request failed",
+                    status_code=resp.status_code,
+                )
 
-        try:
-            payload = resp.json()
-        except Exception as exc:
-            logger.warning(
-                "Google userinfo endpoint returned invalid JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Google userinfo response was invalid",
-                status_code=resp.status_code,
-            ) from exc
+            try:
+                payload = resp.json()
+            except Exception as exc:
+                logger.warning(
+                    "Google userinfo endpoint returned invalid JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Google userinfo response was invalid",
+                    status_code=resp.status_code,
+                ) from exc
 
-        if not isinstance(payload, dict):
-            logger.warning(
-                "Google userinfo endpoint returned non-object JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Google userinfo response was invalid",
-                status_code=resp.status_code,
-            )
-        return payload
+            if not isinstance(payload, dict):
+                logger.warning(
+                    "Google userinfo endpoint returned non-object JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Google userinfo response was invalid",
+                    status_code=resp.status_code,
+                )
+            return payload
 
     async def _request_token(
         self,
@@ -325,7 +325,7 @@ class GoogleProviderAdapter(ProviderAdapter):
                     "Google token request failed",
                     status_code=503,
                 ) from exc
-        return self._parse_token_response(resp, context=context)
+            return self._parse_token_response(resp, context=context)
 
     def _parse_token_response(self, resp: Any, *, context: str) -> _GoogleTokenResponse:
         if resp.status_code != 200:

--- a/src/mxcp/sdk/auth/providers/keycloak.py
+++ b/src/mxcp/sdk/auth/providers/keycloak.py
@@ -225,53 +225,53 @@ class KeycloakProviderAdapter(ProviderAdapter):
                     status_code=503,
                 ) from exc
 
-        if resp.status_code != 200:
-            logger.warning(
-                "Keycloak userinfo endpoint returned non-200",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Keycloak userinfo request failed",
-                status_code=resp.status_code,
-            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Keycloak userinfo endpoint returned non-200",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Keycloak userinfo request failed",
+                    status_code=resp.status_code,
+                )
 
-        try:
-            payload = resp.json()
-        except Exception as exc:
-            logger.warning(
-                "Keycloak userinfo endpoint returned invalid JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Keycloak userinfo response was invalid",
-                status_code=resp.status_code,
-            ) from exc
+            try:
+                payload = resp.json()
+            except Exception as exc:
+                logger.warning(
+                    "Keycloak userinfo endpoint returned invalid JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Keycloak userinfo response was invalid",
+                    status_code=resp.status_code,
+                ) from exc
 
-        if not isinstance(payload, dict):
-            logger.warning(
-                "Keycloak userinfo endpoint returned non-object JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Keycloak userinfo response was invalid",
-                status_code=resp.status_code,
-            )
-        return payload
+            if not isinstance(payload, dict):
+                logger.warning(
+                    "Keycloak userinfo endpoint returned non-object JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Keycloak userinfo response was invalid",
+                    status_code=resp.status_code,
+                )
+            return payload
 
     async def _request_token(
         self,
@@ -301,7 +301,7 @@ class KeycloakProviderAdapter(ProviderAdapter):
                     "Keycloak token request failed",
                     status_code=503,
                 ) from exc
-        return self._parse_token_response(resp, context=context)
+            return self._parse_token_response(resp, context=context)
 
     def _parse_token_response(self, resp: Any, *, context: str) -> _KeycloakTokenResponse:
         if resp.status_code != 200:

--- a/src/mxcp/sdk/auth/providers/oidc.py
+++ b/src/mxcp/sdk/auth/providers/oidc.py
@@ -70,46 +70,46 @@ async def fetch_oidc_discovery(config_url: str) -> OIDCDiscoveryDocument:
                 status_code=503,
             ) from exc
 
-    if resp.status_code != 200:
-        logger.warning(
-            "OIDC discovery endpoint returned non-200",
-            extra={
-                "provider": "oidc",
-                "endpoint": "discovery",
-                "status_code": resp.status_code,
-            },
-        )
-        raise ProviderError(
-            "server_error",
-            "OIDC discovery request failed",
-            status_code=resp.status_code,
-        )
+        if resp.status_code != 200:
+            logger.warning(
+                "OIDC discovery endpoint returned non-200",
+                extra={
+                    "provider": "oidc",
+                    "endpoint": "discovery",
+                    "status_code": resp.status_code,
+                },
+            )
+            raise ProviderError(
+                "server_error",
+                "OIDC discovery request failed",
+                status_code=resp.status_code,
+            )
 
-    try:
-        data = resp.json()
-    except Exception as exc:
-        logger.warning(
-            "OIDC discovery endpoint returned invalid JSON",
-            extra={
-                "provider": "oidc",
-                "endpoint": "discovery",
-                "status_code": resp.status_code,
-            },
-        )
-        raise ProviderError(
-            "server_error",
-            "OIDC discovery response was invalid",
-            status_code=resp.status_code,
-        ) from exc
+        try:
+            data = resp.json()
+        except Exception as exc:
+            logger.warning(
+                "OIDC discovery endpoint returned invalid JSON",
+                extra={
+                    "provider": "oidc",
+                    "endpoint": "discovery",
+                    "status_code": resp.status_code,
+                },
+            )
+            raise ProviderError(
+                "server_error",
+                "OIDC discovery response was invalid",
+                status_code=resp.status_code,
+            ) from exc
 
-    if not isinstance(data, dict):
-        raise ProviderError(
-            "server_error",
-            "OIDC discovery response was not a JSON object",
-            status_code=resp.status_code,
-        )
+        if not isinstance(data, dict):
+            raise ProviderError(
+                "server_error",
+                "OIDC discovery response was not a JSON object",
+                status_code=resp.status_code,
+            )
 
-    return OIDCDiscoveryDocument.model_validate(data)
+        return OIDCDiscoveryDocument.model_validate(data)
 
 
 # ── Internal response models ────────────────────────────────────────────
@@ -396,53 +396,53 @@ class OIDCProviderAdapter(ProviderAdapter):
                     status_code=503,
                 ) from exc
 
-        if resp.status_code != 200:
-            logger.warning(
-                "OIDC userinfo endpoint returned non-200",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "OIDC userinfo request failed",
-                status_code=resp.status_code,
-            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "OIDC userinfo endpoint returned non-200",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "OIDC userinfo request failed",
+                    status_code=resp.status_code,
+                )
 
-        try:
-            payload = resp.json()
-        except Exception as exc:
-            logger.warning(
-                "OIDC userinfo endpoint returned invalid JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "OIDC userinfo response was invalid",
-                status_code=resp.status_code,
-            ) from exc
+            try:
+                payload = resp.json()
+            except Exception as exc:
+                logger.warning(
+                    "OIDC userinfo endpoint returned invalid JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "OIDC userinfo response was invalid",
+                    status_code=resp.status_code,
+                ) from exc
 
-        if not isinstance(payload, dict):
-            logger.warning(
-                "OIDC userinfo endpoint returned non-object JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "OIDC userinfo response was invalid",
-                status_code=resp.status_code,
-            )
-        return payload
+            if not isinstance(payload, dict):
+                logger.warning(
+                    "OIDC userinfo endpoint returned non-object JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "OIDC userinfo response was invalid",
+                    status_code=resp.status_code,
+                )
+            return payload
 
     async def _request_token(
         self,
@@ -475,7 +475,7 @@ class OIDCProviderAdapter(ProviderAdapter):
                     "OIDC token request failed",
                     status_code=503,
                 ) from exc
-        return self._parse_token_response(resp, context=context)
+            return self._parse_token_response(resp, context=context)
 
     def _parse_token_response(self, resp: Any, *, context: str) -> _OIDCTokenResponse:
         if resp.status_code != 200:

--- a/src/mxcp/sdk/auth/providers/salesforce.py
+++ b/src/mxcp/sdk/auth/providers/salesforce.py
@@ -218,53 +218,53 @@ class SalesforceProviderAdapter(ProviderAdapter):
                     status_code=503,
                 ) from exc
 
-        if resp.status_code != 200:
-            logger.warning(
-                "Salesforce userinfo endpoint returned non-200",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Salesforce userinfo request failed",
-                status_code=resp.status_code,
-            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Salesforce userinfo endpoint returned non-200",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Salesforce userinfo request failed",
+                    status_code=resp.status_code,
+                )
 
-        try:
-            payload = resp.json()
-        except Exception as exc:
-            logger.warning(
-                "Salesforce userinfo endpoint returned invalid JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Salesforce userinfo response was invalid",
-                status_code=resp.status_code,
-            ) from exc
+            try:
+                payload = resp.json()
+            except Exception as exc:
+                logger.warning(
+                    "Salesforce userinfo endpoint returned invalid JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Salesforce userinfo response was invalid",
+                    status_code=resp.status_code,
+                ) from exc
 
-        if not isinstance(payload, dict):
-            logger.warning(
-                "Salesforce userinfo endpoint returned non-object JSON",
-                extra={
-                    "provider": self.provider_name,
-                    "endpoint": "userinfo",
-                    "status_code": resp.status_code,
-                },
-            )
-            raise ProviderError(
-                "invalid_token",
-                "Salesforce userinfo response was invalid",
-                status_code=resp.status_code,
-            )
-        return payload
+            if not isinstance(payload, dict):
+                logger.warning(
+                    "Salesforce userinfo endpoint returned non-object JSON",
+                    extra={
+                        "provider": self.provider_name,
+                        "endpoint": "userinfo",
+                        "status_code": resp.status_code,
+                    },
+                )
+                raise ProviderError(
+                    "invalid_token",
+                    "Salesforce userinfo response was invalid",
+                    status_code=resp.status_code,
+                )
+            return payload
 
     async def _request_token(
         self,
@@ -294,7 +294,7 @@ class SalesforceProviderAdapter(ProviderAdapter):
                     "Salesforce token request failed",
                     status_code=503,
                 ) from exc
-        return self._parse_token_response(resp, context=context)
+            return self._parse_token_response(resp, context=context)
 
     def _parse_token_response(self, resp: Any, *, context: str) -> _SalesforceTokenResponse:
         if resp.status_code != 200:

--- a/tests/sdk/auth/test_atlassian_provider_adapter.py
+++ b/tests/sdk/auth/test_atlassian_provider_adapter.py
@@ -113,3 +113,34 @@ async def test_fetch_user_info_requires_account_id(
     monkeypatch.setattr(adapter, "_fetch_me", lambda token: asyncio.sleep(0, {"name": "n"}))
     with pytest.raises(ProviderError):
         await adapter.fetch_user_info(access_token="at")
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_info_happy_path(
+    monkeypatch: MonkeyPatch, atlassian_config: AtlassianAuthConfigModel
+) -> None:
+    get_response = FakeResponse(
+        200,
+        {
+            "account_id": "acct-1",
+            "email": "user@example.com",
+            "name": "User",
+            "picture": "pic",
+            "nickname": "user",
+            "scope": "read:me offline_access",
+        },
+    )
+    post_response = FakeResponse(200, {})
+    fake_client = FakeAsyncHttpClient(
+        post_response=post_response,
+        default_get_response=get_response,
+    )
+    patch_http_client(
+        monkeypatch, "mxcp.sdk.auth.providers.atlassian.create_mcp_http_client", fake_client
+    )
+    adapter = AtlassianProviderAdapter(atlassian_config)
+
+    user_info = await adapter.fetch_user_info(access_token="at")
+    assert user_info.user_id == "acct-1"
+    assert user_info.email == "user@example.com"
+    assert user_info.avatar_url == "pic"

--- a/tests/sdk/auth/test_google_provider_adapter.py
+++ b/tests/sdk/auth/test_google_provider_adapter.py
@@ -127,3 +127,33 @@ async def test_exchange_code_error(
             code_verifier=None,
             scopes=["openid"],
         )
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_info_happy_path(
+    monkeypatch: MonkeyPatch, google_config: GoogleAuthConfigModel
+) -> None:
+    get_response = FakeResponse(
+        200,
+        {
+            "sub": "user-1",
+            "email": "user@example.com",
+            "name": "User",
+            "picture": "pic",
+            "scope": "openid email",
+        },
+    )
+    post_response = FakeResponse(200, {})
+    fake_client = FakeAsyncHttpClient(
+        post_response=post_response,
+        default_get_response=get_response,
+    )
+    patch_http_client(
+        monkeypatch, "mxcp.sdk.auth.providers.google.create_mcp_http_client", fake_client
+    )
+
+    adapter = GoogleProviderAdapter(google_config)
+    user_info = await adapter.fetch_user_info(access_token="at")
+    assert user_info.user_id == "user-1"
+    assert user_info.email == "user@example.com"
+    assert user_info.avatar_url == "pic"

--- a/tests/sdk/auth/test_keycloak_provider_adapter.py
+++ b/tests/sdk/auth/test_keycloak_provider_adapter.py
@@ -160,3 +160,33 @@ async def test_fetch_user_info_happy_path(
     assert user_info.username == "user"
     assert user_info.avatar_url == "pic"
     assert user_info.provider_scopes_granted == ["openid", "email"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_user_info_happy_path_with_http_client(
+    monkeypatch: MonkeyPatch, keycloak_config: KeycloakAuthConfigModel
+) -> None:
+    get_response = FakeResponse(
+        200,
+        {
+            "sub": "user-1",
+            "email": "user@example.com",
+            "preferred_username": "user",
+            "picture": "pic",
+            "scope": "openid profile",
+        },
+    )
+    post_response = FakeResponse(200, {})
+    fake_client = FakeAsyncHttpClient(
+        post_response=post_response,
+        default_get_response=get_response,
+    )
+    patch_http_client(
+        monkeypatch, "mxcp.sdk.auth.providers.keycloak.create_mcp_http_client", fake_client
+    )
+
+    adapter = KeycloakProviderAdapter(keycloak_config)
+    user_info = await adapter.fetch_user_info(access_token="at")
+    assert user_info.user_id == "user-1"
+    assert user_info.email == "user@example.com"
+    assert user_info.avatar_url == "pic"

--- a/tests/sdk/auth/test_oidc_provider_adapter.py
+++ b/tests/sdk/auth/test_oidc_provider_adapter.py
@@ -366,6 +366,37 @@ async def test_fetch_user_info_happy_path(
 
 
 @pytest.mark.asyncio
+async def test_fetch_user_info_happy_path_with_http_client(
+    monkeypatch: MonkeyPatch, oidc_config: OIDCAuthConfigModel
+) -> None:
+    get_response = FakeResponse(
+        200,
+        {
+            "sub": "user-1",
+            "email": "user@example.com",
+            "preferred_username": "user",
+            "picture": "pic",
+            "scope": "openid email",
+        },
+    )
+    post_response = FakeResponse(200, {})
+    fake_client = FakeAsyncHttpClient(
+        post_response=post_response,
+        default_get_response=get_response,
+    )
+    patch_http_client(
+        monkeypatch, "mxcp.sdk.auth.providers.oidc.create_mcp_http_client", fake_client
+    )
+    adapter = OIDCProviderAdapter(oidc_config)
+    _make_ready(adapter, DISCOVERY_DOC)
+
+    user_info = await adapter.fetch_user_info(access_token="at")
+    assert user_info.user_id == "user-1"
+    assert user_info.email == "user@example.com"
+    assert user_info.avatar_url == "pic"
+
+
+@pytest.mark.asyncio
 async def test_fetch_user_info_requires_sub(
     monkeypatch: MonkeyPatch, oidc_config: OIDCAuthConfigModel
 ) -> None:


### PR DESCRIPTION
## Description
Fix provider adapters to handle HTTP responses while the client context is still open (avoids use-after-close issues), and add regression coverage for userinfo fetch flows across multiple providers.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [ ] Tests pass locally with `uv run pytest`
- [ ] Linting passes with `uv run ruff check .`
- [ ] Code formatting passes with `uv run black --check .`
- [ ] Type checking passes with `uv run mypy .`
- [x] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [ ] Sensitive data handling reviewed (if applicable)
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
None.

## Additional Notes
N/A
