### PR TITLE
Fix mxcp log --since filter handling

### DIFF
--- a/src/mxcp/server/services/audit/utils.py
+++ b/src/mxcp/server/services/audit/utils.py
@@ -134,7 +134,7 @@ def map_legacy_query_params(**kwargs: Any) -> dict[str, Any]:
 
     # Map since to start_time
     if since:
-        query_params["start_time"] = parse_time_since(since).isoformat()
+        query_params["start_time"] = parse_time_since(since)
 
     # Map status - now properly supported in new API!
     if status:

--- a/tests/server/test_audit_utils.py
+++ b/tests/server/test_audit_utils.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+from mxcp.server.services.audit.utils import map_legacy_query_params
+
+
+def test_map_legacy_query_params_preserves_datetime_for_since() -> None:
+    params = map_legacy_query_params(since="10m")
+
+    assert "start_time" in params
+    assert isinstance(params["start_time"], datetime)


### PR DESCRIPTION
## Description
Fixes the `mxcp log --since ...` CLI path so the `since` filter is passed as a `datetime` to the audit query backend instead of an ISO string. Adds a regression test covering the legacy query parameter mapping for `since`.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [ ] Tests pass locally with `uv run pytest`
- [ ] Linting passes with `uv run ruff check .`
- [ ] Code formatting passes with `uv run black --check .`
- [ ] Type checking passes with `uv run mypy .`
- [x] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [x] Sensitive data handling reviewed (if applicable)
- [x] Policy enforcement implications considered (if applicable)

## Breaking Changes
If this is a breaking change, describe what users need to do to migrate:

None.

## Additional Notes
Fixes https://github.com/raw-labs/mxcp/issues/181

Verified against `/Users/bgaidioz/IdeaProjects/vertec-poc-mxcp-server`:
- `mxcp log` worked before the change
- `mxcp log --since 10m` failed with `'str' object has no attribute 'isoformat'`
- after the fix, `--since` filters execute successfully

Local validation run:
- `./.venv/bin/pytest tests/server/test_audit_utils.py`
