### PR TITLE
fix: handle field names with leading underscores in Pydantic model creation

### DIFF
--- a/src/mxcp/server/interfaces/server/mcp.py
+++ b/src/mxcp/server/interfaces/server/mcp.py
@@ -1153,7 +1153,7 @@ class RAWMCP:
                 # and record the original name via Field(alias=...) so validation still works.
                 python_name = prop_name
                 if prop_name.startswith("_"):
-                    python_name = "field_" + prop_name.lstrip("_")
+                    python_name = "field_" + prop_name[1:]  # strip exactly one underscore to avoid name collisions
                     field_kwargs["alias"] = prop_name
                     has_aliased_fields = True
 


### PR DESCRIPTION
## Summary

Fixes #184.

Pydantic v2 treats field names starting with `_` as private attributes and raises `PydanticUserError` ("Fields must not use names with leading underscores") when they appear in a `create_model()` call. This blocked users from declaring YAML return types with underscore-prefixed field names such as `__url` or `__type`.

## Changes

In `_create_pydantic_model_from_schema`, when iterating over object properties:

1. **Detect underscore-prefixed names**: if `prop_name` starts with `_`, generate a safe Python identifier (`"field_" + prop_name.lstrip("_")`) and set `Field(alias=prop_name)` so Pydantic maps the alias back to the original name during validation.
2. **Add `populate_by_name=True`** to `ConfigDict` when aliased fields are present, allowing the model to accept both the alias (original YAML name) and the Python identifier.

No change to non-underscore field names — existing behavior is unaffected.

## Example

Before this fix, the following YAML return type definition would raise a `PydanticUserError`:

```yaml
return:
  type: object
  properties:
    __url:
      type: string
    __type:
      type: string
```

After this fix, validation works correctly: `__url` is accepted as an alias for the generated Python field `field_url`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dynamic Pydantic model generation used for endpoint parameter/return validation; mistakes could break validation or change accepted/returned field names for object schemas, though the change is narrowly scoped to underscore-prefixed properties.
> 
> **Overview**
> Fixes generated Pydantic v2 models for JSON Schema `object` properties that start with `_` by renaming them to safe Python identifiers (e.g., `field_x`) and preserving the original key via `Field(alias=...)`.
> 
> When any such aliases are present, the generated model now enables `populate_by_name` so both the alias (original schema/YAML field) and the Python field name can be used during validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bfb987858f4586fbf1cd70ea7f3c6f0e4d9c6b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->