### PR TITLE
Fix admin /config returning DuckDB path for repository_path

### DIFF
--- a/src/mxcp/server/admin/service.py
+++ b/src/mxcp/server/admin/service.py
@@ -87,11 +87,7 @@ class AdminService:
         return ConfigResponse(
             project=project_name,
             profile=self._server.profile_name,
-            repository_path=(
-                str(self._server.runtime_environment.duckdb_runtime.database_config.path)
-                if self._server.runtime_environment
-                else None
-            ),
+            repository_path=str(self._server.site_config_path),
             duckdb_path=(
                 str(self._server.runtime_environment.duckdb_runtime.database_config.path)
                 if self._server.runtime_environment

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -68,6 +68,7 @@ class MockServer:
         self.reload_manager = MockReloadManager()
         self._start_time = datetime.now(timezone.utc)
         self._pid = os.getpid()
+        self.site_config_path = Path("/test/path")
         self.runtime_environment = None  # Add runtime_environment for config tests
         self.enable_sql_tools = True  # Add enable_sql_tools for config tests
         self.audit_logger = None  # Add audit_logger for config tests
@@ -188,7 +189,9 @@ class TestAdminAPI:
         assert data["status"] == "ok"
         assert data["project"] == "test-project"
         assert data["profile"] == "test-profile"
-        # repository_path and duckdb_path can be None if runtime_environment is not initialized
+        assert data["repository_path"] == "/test/path"
+        # duckdb_path can be None if runtime_environment is not initialized
+        assert data["duckdb_path"] is None
         assert data["readonly"] is False
         assert data["debug"] is False
 


### PR DESCRIPTION
## Description
Fix copy-paste bug in `AdminService.get_config_snapshot()` where `repository_path` was set to the DuckDB file path instead of the project root. Changed it to read from `server.site_config_path`, which is always set (defaults to `Path.cwd()`).

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Tests pass locally with `uv run pytest`
- [ ] Linting passes with `uv run ruff check .`
- [ ] Code formatting passes with `uv run black --check .`
- [ ] Type checking passes with `uv run mypy .`
- [x] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities

## Breaking Changes
N/A

## Additional Notes
The `repository_path` field no longer returns `None` when `runtime_environment` is uninitialized, since `site_config_path` is always available on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)