### PR TITLE
Switch dependabot package-ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   # Enable version updates for Python dependencies
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Description
Switch the Dependabot package ecosystem from `pip` to `uv` so that Dependabot
can parse `uv.lock` and propose updates for all dependencies, not just those
with upper version bounds in `pyproject.toml`.

Fixes https://github.com/raw-labs/mxcp/issues/154

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [x] Tests pass locally with `uv run pytest`
- [x] Linting passes with `uv run ruff check .`
- [x] Code formatting passes with `uv run black --check .`
- [x] Type checking passes with `uv run mypy .`
- [ ] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [ ] Sensitive data handling reviewed (if applicable)
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
N/A

## Additional Notes
After merge, Dependabot should start proposing PRs for all dependencies
(not just `mcp`). Monitor the Dependabot tab to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)