### PR TITLE
Fix "Task was destroyed but it is pending" errors on embedded shutdown

### DIFF
--- a/src/mxcp/server/admin/runner.py
+++ b/src/mxcp/server/admin/runner.py
@@ -101,6 +101,7 @@ class AdminAPIRunner:
                 app=app,
                 log_level=uvicorn_log_level,
                 access_log=False,  # Don't spam logs with every request
+                timeout_graceful_shutdown=5,
             )
 
             self._uvicorn_server = uvicorn.Server(config)

--- a/src/mxcp/server/api.py
+++ b/src/mxcp/server/api.py
@@ -171,7 +171,7 @@ class MXCPServer:
         # Ask uvicorn to exit gracefully first; stdio has no uvicorn server,
         # so fall back to immediate task cancellation in that case.
         logger.debug("stop: requesting graceful uvicorn exit")
-        if self._raw_mcp.request_exit():
+        if self._raw_mcp.request_graceful_exit():
             # Wait for the graceful path to complete. If it doesn't finish
             # within half the timeout, force-cancel the lifecycle task.
             logger.debug("stop: waiting for graceful stop")

--- a/src/mxcp/server/api.py
+++ b/src/mxcp/server/api.py
@@ -17,6 +17,7 @@ import asyncio
 import contextlib
 import logging
 import threading
+import time
 from pathlib import Path
 
 from mxcp.server.core.config.site_config import load_site_config
@@ -162,6 +163,11 @@ class MXCPServer:
         if not self._started.is_set():
             return
 
+        deadline = time.monotonic() + max(timeout, 0.0)
+
+        def remaining_timeout() -> float:
+            return max(0.0, deadline - time.monotonic())
+
         # Ask uvicorn to exit gracefully first; stdio has no uvicorn server,
         # so fall back to immediate task cancellation in that case.
         logger.debug("stop: requesting graceful uvicorn exit")
@@ -169,7 +175,8 @@ class MXCPServer:
             # Wait for the graceful path to complete. If it doesn't finish
             # within half the timeout, force-cancel the lifecycle task.
             logger.debug("stop: waiting for graceful stop")
-            if not self._stopped.wait(timeout=timeout / 2):
+            graceful_timeout = min(timeout / 2, remaining_timeout())
+            if not self._stopped.wait(timeout=graceful_timeout):
                 logger.debug("stop: graceful stop timed out, cancelling server task")
                 if self._loop and self._task and not self._task.done():
                     self._loop.call_soon_threadsafe(self._task.cancel)
@@ -179,11 +186,13 @@ class MXCPServer:
                 self._loop.call_soon_threadsafe(self._task.cancel)
 
         logger.debug("stop: waiting for server to stop")
-        self._stopped.wait(timeout=timeout / 2)
+        self._stopped.wait(timeout=min(timeout / 2, remaining_timeout()))
 
         if self._thread and self._thread.is_alive():
-            logger.debug("stop: joining server thread")
-            self._thread.join(timeout=timeout)
+            join_timeout = remaining_timeout()
+            if join_timeout > 0:
+                logger.debug("stop: joining server thread")
+                self._thread.join(timeout=join_timeout)
 
         logger.debug("stop: running cleanup")
         self._cleanup()

--- a/src/mxcp/server/api.py
+++ b/src/mxcp/server/api.py
@@ -242,17 +242,13 @@ class MXCPServer:
             # Cancel any leftover tasks (e.g. sse_starlette _shutdown_watcher,
             # Windows IocpProactor.accept) before closing the loop so they don't
             # trigger "Task was destroyed but it is pending!" warnings.
-            pending = [
-                t for t in asyncio.all_tasks(self._loop) if not t.done()
-            ]
+            pending = [t for t in asyncio.all_tasks(self._loop) if not t.done()]
             for t in pending:
                 t.cancel()
             if pending:
                 logger.debug("lifecycle: cancelling %d leftover tasks", len(pending))
                 with contextlib.suppress(asyncio.CancelledError):
-                    self._loop.run_until_complete(
-                        asyncio.gather(*pending, return_exceptions=True)
-                    )
+                    self._loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
 
             logger.debug("lifecycle: closing event loop")
             self._loop.close()

--- a/src/mxcp/server/api.py
+++ b/src/mxcp/server/api.py
@@ -162,12 +162,21 @@ class MXCPServer:
         if not self._started.is_set():
             return
 
-        logger.debug("stop: cancelling server task")
-        if self._loop and self._task and not self._task.done():
-            self._loop.call_soon_threadsafe(self._task.cancel)
+        # Ask uvicorn to exit gracefully first; this lets the serve loop
+        # finish on its own without CancelledError noise.
+        logger.debug("stop: requesting graceful uvicorn exit")
+        self._raw_mcp.request_exit()
+
+        # Wait for the graceful path to complete.  If it doesn't finish
+        # within half the timeout, force-cancel the lifecycle task.
+        logger.debug("stop: waiting for graceful stop")
+        if not self._stopped.wait(timeout=timeout / 2):
+            logger.debug("stop: graceful stop timed out, cancelling server task")
+            if self._loop and self._task and not self._task.done():
+                self._loop.call_soon_threadsafe(self._task.cancel)
 
         logger.debug("stop: waiting for server to stop")
-        self._stopped.wait(timeout=timeout)
+        self._stopped.wait(timeout=timeout / 2)
 
         if self._thread and self._thread.is_alive():
             logger.debug("stop: joining server thread")
@@ -230,6 +239,21 @@ class MXCPServer:
                 with contextlib.suppress(asyncio.CancelledError, KeyboardInterrupt):
                     self._loop.run_until_complete(self._task)
         finally:
+            # Cancel any leftover tasks (e.g. sse_starlette _shutdown_watcher,
+            # Windows IocpProactor.accept) before closing the loop so they don't
+            # trigger "Task was destroyed but it is pending!" warnings.
+            pending = [
+                t for t in asyncio.all_tasks(self._loop) if not t.done()
+            ]
+            for t in pending:
+                t.cancel()
+            if pending:
+                logger.debug("lifecycle: cancelling %d leftover tasks", len(pending))
+                with contextlib.suppress(asyncio.CancelledError):
+                    self._loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+
             logger.debug("lifecycle: closing event loop")
             self._loop.close()
             self._stopped.set()

--- a/src/mxcp/server/api.py
+++ b/src/mxcp/server/api.py
@@ -162,16 +162,19 @@ class MXCPServer:
         if not self._started.is_set():
             return
 
-        # Ask uvicorn to exit gracefully first; this lets the serve loop
-        # finish on its own without CancelledError noise.
+        # Ask uvicorn to exit gracefully first; stdio has no uvicorn server,
+        # so fall back to immediate task cancellation in that case.
         logger.debug("stop: requesting graceful uvicorn exit")
-        self._raw_mcp.request_exit()
-
-        # Wait for the graceful path to complete.  If it doesn't finish
-        # within half the timeout, force-cancel the lifecycle task.
-        logger.debug("stop: waiting for graceful stop")
-        if not self._stopped.wait(timeout=timeout / 2):
-            logger.debug("stop: graceful stop timed out, cancelling server task")
+        if self._raw_mcp.request_exit():
+            # Wait for the graceful path to complete. If it doesn't finish
+            # within half the timeout, force-cancel the lifecycle task.
+            logger.debug("stop: waiting for graceful stop")
+            if not self._stopped.wait(timeout=timeout / 2):
+                logger.debug("stop: graceful stop timed out, cancelling server task")
+                if self._loop and self._task and not self._task.done():
+                    self._loop.call_soon_threadsafe(self._task.cancel)
+        else:
+            logger.debug("stop: no uvicorn server, cancelling server task immediately")
             if self._loop and self._task and not self._task.done():
                 self._loop.call_soon_threadsafe(self._task.cancel)
 

--- a/src/mxcp/server/interfaces/server/mcp.py
+++ b/src/mxcp/server/interfaces/server/mcp.py
@@ -283,6 +283,9 @@ class RAWMCP:
         # Initialize runtime components
         self.initialize_runtime_components()
 
+        # Uvicorn server reference for graceful shutdown from embedders
+        self._uvicorn_server: uvicorn.Server | None = None
+
         # Initialize OAuth authentication
         self._initialize_oauth()
 
@@ -672,6 +675,7 @@ class RAWMCP:
         startup_timeout: float = 10.0,
     ) -> None:
         """Run a uvicorn server and surface readiness after startup succeeds."""
+        self._uvicorn_server = server
         serve_task = asyncio.create_task(server.serve())
         startup_deadline = time.monotonic() + startup_timeout
 
@@ -984,6 +988,16 @@ class RAWMCP:
         return self.reload_manager.request_reload(
             payload_func=reload_config_files, description="Configuration reload (SIGHUP)"
         )
+
+    def request_exit(self) -> None:
+        """Signal uvicorn to exit gracefully.
+
+        Thread-safe. Can be called from any thread to initiate a clean
+        shutdown without cancelling asyncio tasks. The server loop will
+        finish naturally, triggering the normal shutdown path.
+        """
+        if self._uvicorn_server is not None:
+            self._uvicorn_server.should_exit = True
 
     async def shutdown(self) -> None:
         """Shutdown the server gracefully."""

--- a/src/mxcp/server/interfaces/server/mcp.py
+++ b/src/mxcp/server/interfaces/server/mcp.py
@@ -989,7 +989,7 @@ class RAWMCP:
             payload_func=reload_config_files, description="Configuration reload (SIGHUP)"
         )
 
-    def request_exit(self) -> None:
+    def request_exit(self) -> bool:
         """Signal uvicorn to exit gracefully.
 
         Thread-safe. Can be called from any thread to initiate a clean
@@ -998,6 +998,8 @@ class RAWMCP:
         """
         if self._uvicorn_server is not None:
             self._uvicorn_server.should_exit = True
+            return True
+        return False
 
     async def shutdown(self) -> None:
         """Shutdown the server gracefully."""

--- a/src/mxcp/server/interfaces/server/mcp.py
+++ b/src/mxcp/server/interfaces/server/mcp.py
@@ -991,7 +991,7 @@ class RAWMCP:
             payload_func=reload_config_files, description="Configuration reload (SIGHUP)"
         )
 
-    def request_exit(self) -> bool:
+    def request_graceful_exit(self) -> bool:
         """Signal uvicorn to exit gracefully.
 
         Thread-safe. Can be called from any thread to initiate a clean

--- a/src/mxcp/server/interfaces/server/mcp.py
+++ b/src/mxcp/server/interfaces/server/mcp.py
@@ -731,6 +731,7 @@ class RAWMCP:
                     host=self.mcp.settings.host,
                     port=self.mcp.settings.port,
                     log_level=self.mcp.settings.log_level.lower(),
+                    timeout_graceful_shutdown=5,
                 )
                 server = uvicorn.Server(config)
                 await self._serve_uvicorn(server, on_ready=on_ready)
@@ -742,6 +743,7 @@ class RAWMCP:
                     host=self.mcp.settings.host,
                     port=self.mcp.settings.port,
                     log_level=self.mcp.settings.log_level.lower(),
+                    timeout_graceful_shutdown=5,
                 )
                 server = uvicorn.Server(config)
                 await self._serve_uvicorn(server, on_ready=on_ready)

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -3,7 +3,7 @@ import contextlib
 import os
 import threading
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -82,6 +82,44 @@ def test_start_marks_running_after_ready_callback(mcp_repo_path):
 
     if server._thread is not None:
         server._thread.join(timeout=1)
+
+
+def test_stop_stdio_cancels_immediately_without_graceful_wait(mcp_repo_path):
+    """Test that stdio shutdown skips the uvicorn grace period entirely."""
+    server = MXCPServer(site_config_path=mcp_repo_path, analytics=False, transport="stdio")
+    server._started.set()
+    server._stopped = Mock()
+    server._stopped.wait.return_value = False
+    server._loop = Mock()
+    server._task = Mock()
+    server._task.done.return_value = False
+
+    events: list[tuple[str, float | None]] = []
+
+    def record_request_exit() -> bool:
+        events.append(("request_exit", None))
+        return False
+
+    def record_cancel(callback) -> None:
+        assert callback is server._task.cancel
+        events.append(("cancel", None))
+
+    def record_wait(*, timeout: float) -> bool:
+        events.append(("wait", timeout))
+        return False
+
+    server.raw_mcp.request_exit = Mock(side_effect=record_request_exit)
+    server._loop.call_soon_threadsafe.side_effect = record_cancel
+    server._stopped.wait.side_effect = record_wait
+
+    with patch.object(server, "_cleanup"):
+        server.stop()
+
+    assert events == [
+        ("request_exit", None),
+        ("cancel", None),
+        ("wait", 5.0),
+    ]
 
 
 def test_cleanup_does_not_release_unrelated_thread_state(mcp_repo_path):

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -96,8 +96,8 @@ def test_stop_stdio_cancels_immediately_without_graceful_wait(mcp_repo_path):
 
     events: list[tuple[str, float | None]] = []
 
-    def record_request_exit() -> bool:
-        events.append(("request_exit", None))
+    def record_request_graceful_exit() -> bool:
+        events.append(("request_graceful_exit", None))
         return False
 
     def record_cancel(callback) -> None:
@@ -108,7 +108,7 @@ def test_stop_stdio_cancels_immediately_without_graceful_wait(mcp_repo_path):
         events.append(("wait", timeout))
         return False
 
-    server.raw_mcp.request_exit = Mock(side_effect=record_request_exit)
+    server.raw_mcp.request_graceful_exit = Mock(side_effect=record_request_graceful_exit)
     server._loop.call_soon_threadsafe.side_effect = record_cancel
     server._stopped.wait.side_effect = record_wait
 
@@ -116,7 +116,7 @@ def test_stop_stdio_cancels_immediately_without_graceful_wait(mcp_repo_path):
         server.stop()
 
     assert events == [
-        ("request_exit", None),
+        ("request_graceful_exit", None),
         ("cancel", None),
         ("wait", 5.0),
     ]
@@ -145,7 +145,7 @@ def test_stop_stays_within_timeout_budget(mcp_repo_path):
         now += timeout
         return False
 
-    server.raw_mcp.request_exit = Mock(return_value=True)
+    server.raw_mcp.request_graceful_exit = Mock(return_value=True)
     server._stopped.wait.side_effect = record_wait
 
     with (

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -122,6 +122,42 @@ def test_stop_stdio_cancels_immediately_without_graceful_wait(mcp_repo_path):
     ]
 
 
+def test_stop_stays_within_timeout_budget(mcp_repo_path):
+    """Test that stop() does not wait past its declared timeout."""
+    server = MXCPServer(site_config_path=mcp_repo_path, analytics=False)
+    server._started.set()
+    server._stopped = Mock()
+    server._loop = Mock()
+    server._task = Mock()
+    server._task.done.return_value = False
+    server._thread = Mock()
+    server._thread.is_alive.return_value = True
+
+    now = 100.0
+    waits: list[float] = []
+
+    def monotonic() -> float:
+        return now
+
+    def record_wait(*, timeout: float) -> bool:
+        nonlocal now
+        waits.append(timeout)
+        now += timeout
+        return False
+
+    server.raw_mcp.request_exit = Mock(return_value=True)
+    server._stopped.wait.side_effect = record_wait
+
+    with (
+        patch("mxcp.server.api.time.monotonic", side_effect=monotonic),
+        patch.object(server, "_cleanup"),
+    ):
+        server.stop(timeout=10.0)
+
+    assert waits == [5.0, 5.0]
+    server._thread.join.assert_not_called()
+
+
 def test_cleanup_does_not_release_unrelated_thread_state(mcp_repo_path):
     """Test that cleanup does not touch private state on host-managed threads."""
     server = MXCPServer(

--- a/uv.lock
+++ b/uv.lock
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "mxcp"
-version = "0.12.0"
+version = "0.12.2rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
When MXCPServer.stop() is called from an embedding host (e.g. a .NET process via Python.NET), the previous implementation immediately cancelled the lifecycle asyncio task. This caused two problems:

1. Uvicorn's in-flight ASGI handlers received CancelledError, producing noisy ERROR-level tracebacks from starlette/uvicorn even though shutdown was otherwise successful.

2. Background tasks that outlive the server (sse_starlette's _shutdown_watcher polling loop, and on Windows the IocpProactor.accept coroutine) were never cancelled before the event loop was closed, triggering asyncio's "Task was destroyed but it is pending!" warning.

The fix has three parts:

RAWMCP.request_exit() — new thread-safe method that sets uvicorn's should_exit flag, letting the serve loop finish naturally through uvicorn's own graceful shutdown path instead of being killed by CancelledError.

MXCPServer.stop() — now calls request_exit() first and waits up to half the timeout for graceful shutdown. Only falls back to force- cancelling the lifecycle task if the graceful path doesn't complete in time.

_run_blocking() finally block — after the lifecycle coroutine exits (gracefully or not), any remaining pending tasks on the event loop are cancelled and awaited via asyncio.gather() before the loop is closed. This prevents the "destroyed but pending" warnings from stragglers like _shutdown_watcher.

## Description
Brief description of the changes in this PR.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [ ] Tests pass locally with `uv run pytest`
- [ ] Linting passes with `uv run ruff check .`
- [ ] Code formatting passes with `uv run black --check .`
- [ ] Type checking passes with `uv run mypy .`
- [ ] Added tests for new functionality (if applicable)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [ ] This change does not introduce security vulnerabilities
- [ ] Sensitive data handling reviewed (if applicable)
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
If this is a breaking change, describe what users need to do to migrate:

## Additional Notes
Any additional context or screenshots.