### PR TITLE
Add user-facing docs for capability mapping and usage

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -246,20 +246,25 @@ claims using `claim_mappings`. Those capabilities are available in Python throug
 the authenticated user context.
 
 ```python
+from mxcp.sdk.auth.context import get_user_context
+
 @udf
-def can_manage_billing(self) -> bool:
-    if not self.user_context:
-        return False
-    return "billing.manage" in self.user_context.capabilities
+def get_capabilities(self) -> dict:
+    context = get_user_context()
+    if context is None:
+        return {"username": None, "email": None, "capabilities": [], "raw_profile": {}}
+
+    return {
+        "username": context.username,
+        "email": context.email,
+        "capabilities": list(context.capabilities),
+        "raw_profile": context.raw_profile or {},
+    }
 ```
 
-```python
-@udf
-def get_visible_report(self) -> dict:
-    if not self.user_context or "reports.view" not in self.user_context.capabilities:
-        raise PermissionError("reports.view capability required")
-    return {"status": "ok"}
-```
+This matches the pattern used by the OAuth plugin examples: fetch the current user
+with `get_user_context()`, then read `external_token`, `raw_profile`, or
+`capabilities` from that context as needed.
 
 Use Python capability checks for endpoint-specific business logic. For declarative
 authorization and output redaction, prefer CEL policies with `user.capabilities`.

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -239,6 +239,31 @@ self.get_user_token() -> Optional[str]
 self.user_context -> Optional[UserContext]
 ```
 
+### Accessing Capabilities in Python
+
+When authentication is enabled, MXCP may derive capabilities from OAuth or OIDC
+claims using `claim_mappings`. Those capabilities are available in Python through
+the authenticated user context.
+
+```python
+@udf
+def can_manage_billing(self) -> bool:
+    if not self.user_context:
+        return False
+    return "billing.manage" in self.user_context.capabilities
+```
+
+```python
+@udf
+def get_visible_report(self) -> dict:
+    if not self.user_context or "reports.view" not in self.user_context.capabilities:
+        raise PermissionError("reports.view capability required")
+    return {"status": "ok"}
+```
+
+Use Python capability checks for endpoint-specific business logic. For declarative
+authorization and output redaction, prefer CEL policies with `user.capabilities`.
+
 ### External API Calls
 
 ```python

--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -138,33 +138,32 @@ if site_cfg:
 
 ## User Context
 
-Python endpoints run with an execution context that may include an authenticated
-user. When OAuth capability mapping is configured, derived capabilities are
-available on that user context.
+Python endpoints can access the authenticated user directly through
+`get_user_context()`. When OAuth capability mapping is configured, derived
+capabilities are available on that user context.
 
-Use the executor context API to inspect the authenticated user:
+Use the auth context API to inspect the authenticated user:
 
 ```python
-from mxcp.sdk.executor import get_execution_context
+from mxcp.sdk.auth.context import get_user_context
 
-def my_endpoint() -> dict:
-    ctx = get_execution_context()
-    user = ctx.user_context if ctx else None
-
-    if not user:
-        raise PermissionError("Authentication required")
-
-    if "reports.view" not in user.capabilities:
-        raise PermissionError("reports.view capability required")
+def get_capabilities() -> dict:
+    context = get_user_context()
+    if context is None:
+        return {"username": None, "email": None, "capabilities": [], "raw_profile": {}}
 
     return {
-        "user_id": user.user_id,
-        "provider": user.provider,
-        "capabilities": user.capabilities,
+        "username": context.username,
+        "email": context.email,
+        "capabilities": list(context.capabilities),
+        "raw_profile": context.raw_profile or {},
     }
 ```
 
-Common fields on `ctx.user_context`:
+This is the same access pattern used in the Python OAuth examples, including the
+Google Calendar example.
+
+Common fields on the returned user context:
 
 - `user_id`
 - `username`

--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -136,6 +136,46 @@ if site_cfg:
 
 **Returns:** `dict | None` - Site configuration or None
 
+## User Context
+
+Python endpoints run with an execution context that may include an authenticated
+user. When OAuth capability mapping is configured, derived capabilities are
+available on that user context.
+
+Use the executor context API to inspect the authenticated user:
+
+```python
+from mxcp.sdk.executor import get_execution_context
+
+def my_endpoint() -> dict:
+    ctx = get_execution_context()
+    user = ctx.user_context if ctx else None
+
+    if not user:
+        raise PermissionError("Authentication required")
+
+    if "reports.view" not in user.capabilities:
+        raise PermissionError("reports.view capability required")
+
+    return {
+        "user_id": user.user_id,
+        "provider": user.provider,
+        "capabilities": user.capabilities,
+    }
+```
+
+Common fields on `ctx.user_context`:
+
+- `user_id`
+- `username`
+- `email`
+- `provider`
+- `external_token`
+- `capabilities`
+
+Prefer CEL policies for declarative authorization and output redaction. Use
+Python user-context checks when the rule is part of endpoint-specific logic.
+
 ## Plugin Access
 
 ### plugins.get()

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -64,6 +64,85 @@ projects:
             callback_path: /callback
             auth_url: https://github.com/login/oauth/authorize
             token_url: https://github.com/login/oauth/access_token
+
+### Mapping IdP Claims to MXCP Capabilities
+
+MXCP can derive internal authorization capabilities from OAuth/OIDC claims in the
+authenticated user's profile. This is configured with `claim_mappings` on the active
+provider block in `config.yml`.
+
+Use this when you want to:
+
+- Map provider roles or groups to internal capability names
+- Map OAuth scopes to capabilities used by CEL policies
+- Reuse the same capability names across different identity providers
+
+Example:
+
+```yaml
+mxcp: 1
+projects:
+  my-project:
+    profiles:
+      default:
+        auth:
+          provider: oidc
+          oidc:
+            config_url: "https://mycompany.auth0.com/.well-known/openid-configuration"
+            client_id: "${AUTH0_CLIENT_ID}"
+            client_secret: "${AUTH0_CLIENT_SECRET}"
+            scope: "openid profile email"
+            callback_path: /oidc/callback
+            claim_mappings:
+              "https://mycompany.com/roles":
+                "admin": [admin, billing.manage, reports.view]
+                "billing-manager": [billing.manage]
+              "https://mycompany.com/groups":
+                "finance-team": [billing.manage]
+              "scope":
+                "https://www.googleapis.com/auth/calendar.readonly": [calendar.read]
+```
+
+How mapping works:
+
+- Mapping keys are claim paths in the authenticated user's raw profile
+- Top-level claims are supported: `"scope"`
+- Nested claims are supported: `"realm_access.roles"`
+- URI-style claim names are supported: `"https://mycompany.com/roles"`
+- A matched claim value can produce one or more capabilities
+
+Supported claim value shapes:
+
+- Lists such as `["admin", "viewer"]`
+- Space-separated strings such as `"openid profile email"`
+- Single scalar values such as `"engineering"` or `true`
+
+Capabilities are derived on each authenticated request and then exposed to:
+
+- CEL policies as `user.capabilities`
+- Python plugin code as `self.user_context.capabilities`
+
+For Keycloak, nested role claims typically look like this:
+
+```yaml
+auth:
+  provider: keycloak
+  keycloak:
+    client_id: "${KC_CLIENT_ID}"
+    client_secret: "${KC_CLIENT_SECRET}"
+    realm: "mxcp"
+    server_url: "https://keycloak.internal"
+    scope: "openid profile email"
+    callback_path: /keycloak/callback
+    claim_mappings:
+      "realm_access.roles":
+        "admin": [admin]
+        "billing-manager": [billing.manage]
+      "resource_access.mxcp-client.roles":
+        "report-viewer": [reports.view]
+```
+
+Use [Policies](/security/policies) to enforce these capabilities declaratively.
 ```
 
 ### Disable Authentication

--- a/docs/security/policies.md
+++ b/docs/security/policies.md
@@ -71,12 +71,14 @@ Conditions use a CEL-like expression syntax:
 
 | Variable | Type | Description |
 |----------|------|-------------|
-| `user.id` | string | User identifier |
+| `user.user_id` | string | User identifier |
+| `user.username` | string | User login or handle |
 | `user.email` | string | User email address |
 | `user.name` | string | User display name |
+| `user.provider` | string | Auth provider name |
 | `user.role` | string | Primary role |
 | `user.permissions` | array | List of permissions |
-| `user.groups` | array | Group memberships |
+| `user.capabilities` | array | Capabilities derived from IdP claims via `claim_mappings` |
 
 For anonymous users (when no authentication is configured), the user context defaults to:
 
@@ -84,6 +86,7 @@ For anonymous users (when no authentication is configured), the user context def
 {
   "role": "anonymous",
   "permissions": [],
+  "capabilities": [],
   "user_id": null,
   "username": null,
   "email": null,
@@ -106,7 +109,8 @@ Example context for an endpoint with parameters `employee_id` and `department`:
   "user": {
     "user_id": "123",
     "role": "admin",
-    "permissions": ["employee.read"]
+    "permissions": ["employee.read"],
+    "capabilities": ["employee.read", "employee.write"]
   },
   "employee_id": "emp456",
   "department": "engineering"
@@ -132,7 +136,8 @@ Example context for an employee endpoint response:
   "user": {
     "user_id": "123",
     "role": "user",
-    "permissions": ["employee.read"]
+    "permissions": ["employee.read"],
+    "capabilities": ["employee.read"]
   },
   "response": {
     "id": "emp456",
@@ -273,6 +278,49 @@ condition: "'employee.read' in user.permissions && 'employee.write' in user.perm
 # Check for any of several permissions
 condition: "user.permissions.exists(p, p in ['admin', 'manager'])"
 ```
+
+### Capability Checks
+
+Capabilities are the internal authorization vocabulary derived from OAuth or OIDC
+claims using `claim_mappings` in your auth provider configuration.
+
+```yaml
+# Deny access unless the user has a capability
+condition: '! ("billing.manage" in user.capabilities)'
+action: deny
+reason: "billing.manage capability required"
+```
+
+```yaml
+# Equivalent form using exists()
+condition: '! user.capabilities.exists(c, c == "reports.view")'
+action: deny
+reason: "reports.view capability required"
+```
+
+You can use capabilities for both input and output policies:
+
+```yaml
+tool:
+  name: employee_data
+  policies:
+    input:
+      - condition: '! ("employee.read" in user.capabilities)'
+        action: deny
+        reason: "employee.read capability required"
+    output:
+      - condition: '! ("employee.view_sensitive" in user.capabilities)'
+        action: mask_fields
+        fields: ["salary", "ssn"]
+        reason: "Sensitive fields require employee.view_sensitive"
+```
+
+Output policy behavior:
+
+- `deny` blocks the entire response
+- `filter_fields` removes named fields
+- `mask_fields` replaces named fields with masked values
+- `filter_sensitive_fields` removes fields marked `sensitive: true` in the return schema
 
 ### Parameter-based Policies
 


### PR DESCRIPTION
## Summary
- document `claim_mappings` in the authentication guide with provider examples
- document `user.capabilities` in CEL policies, including deny and redaction use cases
- document capability access from Python plugins and Python endpoints

Closes #251

## Testing
- reviewed rendered markdown content via diff
