### PR TITLE
Fix pandas-stubs mypy regression in validator output handling

### DIFF
--- a/src/mxcp/sdk/validator/converters.py
+++ b/src/mxcp/sdk/validator/converters.py
@@ -21,6 +21,16 @@ class TypeConverter:
     """Utility class for type conversion and validation."""
 
     @staticmethod
+    def _normalize_pandas_dataframe_nulls(value: pd.DataFrame) -> pd.DataFrame:
+        """Convert pandas null sentinels into Python None for output handling."""
+        return value.astype(object).where(value.notna(), None)
+
+    @staticmethod
+    def _normalize_pandas_series_nulls(value: pd.Series) -> pd.Series:
+        """Convert pandas null sentinels into Python None for output handling."""
+        return value.astype(object).where(value.notna(), None)
+
+    @staticmethod
     def python_type_to_schema_type(python_type: str) -> str:
         """Map Python type names to schema types."""
         type_map = {
@@ -238,13 +248,13 @@ class TypeConverter:
                     f"DataFrame rows must be objects, but schema expects array of {schema.items.type}"
                 )
             # Convert DataFrame to list of dicts for validation
-            value = value.replace({pd.NaT: None}).to_dict("records")
+            value = TypeConverter._normalize_pandas_dataframe_nulls(value).to_dict("records")
 
         # Handle Series - they validate as arrays
         if isinstance(value, pd.Series):
             if return_type != "array":
                 raise ValidationError(f"Expected {return_type}, got Series (which is array)")
-            value = value.replace({pd.NaT: None}).tolist()
+            value = TypeConverter._normalize_pandas_series_nulls(value).tolist()
 
         if return_type == "string":
             if (
@@ -355,10 +365,10 @@ class TypeConverter:
             return [TypeConverter.serialize_for_output(item) for item in items]
         elif isinstance(obj, pd.DataFrame):
             # Convert DataFrame to list of dicts
-            return obj.replace({pd.NaT: None}).to_dict("records")
+            return TypeConverter._normalize_pandas_dataframe_nulls(obj).to_dict("records")
         elif isinstance(obj, pd.Series):
             # Convert Series to list
-            return obj.replace({pd.NaT: None}).tolist()
+            return TypeConverter._normalize_pandas_series_nulls(obj).tolist()
         elif isinstance(obj, pd.Timestamp | datetime | date | time):
             return obj.isoformat()
         elif isinstance(obj, type(pd.NaT)):

--- a/tests/sdk/validator/test_core.py
+++ b/tests/sdk/validator/test_core.py
@@ -255,6 +255,35 @@ class TestTypeValidator:
         result = validator.validate_output(df)
         assert result == [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
 
+    def test_dataframe_output_with_nat(self):
+        """Test DataFrame output validation converts NaT values to None."""
+        schema = {
+            "output": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "created_at": {"type": "string", "format": "date-time"},
+                    },
+                },
+            }
+        }
+
+        validator = TypeValidator.from_dict(schema)
+        df = pd.DataFrame(
+            [
+                {"id": 1, "created_at": pd.Timestamp("2024-01-01T00:00:00")},
+                {"id": 2, "created_at": pd.NaT},
+            ]
+        )
+
+        result = validator.validate_output(df)
+        assert result == [
+            {"id": 1, "created_at": pd.Timestamp("2024-01-01T00:00:00")},
+            {"id": 2, "created_at": None},
+        ]
+
     def test_series_output(self):
         """Test Series output validation."""
         schema = {"output": {"type": "array", "items": {"type": "number"}}}
@@ -265,6 +294,16 @@ class TestTypeValidator:
         series = pd.Series([1.0, 2.0, 3.0])
         result = validator.validate_output(series)
         assert result == [1.0, 2.0, 3.0]
+
+    def test_series_output_with_nat(self):
+        """Test Series output validation converts NaT values to None."""
+        schema = {"output": {"type": "array", "items": {"type": "string", "format": "date-time"}}}
+
+        validator = TypeValidator.from_dict(schema)
+        series = pd.Series([pd.Timestamp("2024-01-01T00:00:00"), pd.NaT])
+
+        result = validator.validate_output(series)
+        assert result == [pd.Timestamp("2024-01-01T00:00:00"), None]
 
     def test_sensitive_field_masking(self):
         """Test sensitive field masking."""


### PR DESCRIPTION
## Summary
- replace `replace({pd.NaT: None})` with typed-safe pandas null normalization in validator output paths
- keep DataFrame and Series handling behavior the same while avoiding the stricter `pandas-stubs` replacement-map typing error
- add regression tests for `NaT` in DataFrame and Series outputs

## Why
PR #271 bumps `pandas-stubs` and makes `uv run mypy .` fail in CI on `src/mxcp/sdk/validator/converters.py` because the `replace({pd.NaT: None})` pattern is typed more strictly.

## Testing
- `uv run ruff check .`
- `uv run black --check --diff .`
- `uv run mypy .`
- `env -u OP_SERVICE_ACCOUNT_TOKEN uv run pytest --cov=src/mxcp --cov-report=xml --cov-report=term-missing`

## Notes
- The full local pytest run only needed `OP_SERVICE_ACCOUNT_TOKEN` unset because one existing config test assumes that variable is absent.