### PR TITLE
Fix pandas-stubs where() call-overload error in null normalization

### DIFF
--- a/src/mxcp/sdk/validator/converters.py
+++ b/src/mxcp/sdk/validator/converters.py
@@ -23,12 +23,14 @@ class TypeConverter:
     @staticmethod
     def _normalize_pandas_dataframe_nulls(value: pd.DataFrame) -> pd.DataFrame:
         """Convert pandas null sentinels into Python None for output handling."""
-        return value.astype(object).where(value.notna(), None)
+        # pandas-stubs rejects None as the `other` arg of where(), but it is supported at runtime.
+        return value.astype(object).where(value.notna(), None)  # type: ignore[call-overload,no-any-return]
 
     @staticmethod
     def _normalize_pandas_series_nulls(value: pd.Series) -> pd.Series:
         """Convert pandas null sentinels into Python None for output handling."""
-        return value.astype(object).where(value.notna(), None)
+        # pandas-stubs rejects None as the `other` arg of where(), but it is supported at runtime.
+        return value.astype(object).where(value.notna(), None)  # type: ignore[call-overload,no-any-return]
 
     @staticmethod
     def python_type_to_schema_type(python_type: str) -> str:


### PR DESCRIPTION
## Summary
- Add `# type: ignore[call-overload,no-any-return]` to the two `where(value.notna(), None)` calls in `_normalize_pandas_dataframe_nulls` / `_normalize_pandas_series_nulls`.
- Inline comment notes that pandas-stubs rejects `None` as the `other` arg but it is supported at runtime.

## Why
PR #278 (commit bccf95a on this branch) tried to fix the `pandas-stubs` mypy regression by swapping `replace({pd.NaT: None})` for `astype(object).where(value.notna(), None)`. But `pandas-stubs` 2.3.3.260113 also rejects `None` as the `other` argument of `DataFrame.where` / `Series.where`, so the lint step still fails on the same lines with `[call-overload]` plus a cascading `[no-any-return]`.

This is a well-known gap in pandas-stubs — the standard workaround is an inline `# type: ignore`. The fix keeps the existing helper structure introduced in #278 (plus its NaT regression tests) and just silences the overload error.

> ⚠️ Note: PR #278 was merged without ever running CI because the workflow filter `branches: '*'` doesn't match branch names with slashes (so a PR whose base is a dependabot branch never triggers). This PR has the same limitation. Recommended to verify by re-running CI on PR #271 after merge.

## Testing
- `uv run ruff check .` ✅
- `uv run black --check --diff .` ✅
- `uv run mypy .` ✅ (Success: no issues found in 171 source files)
- `env -u OP_SERVICE_ACCOUNT_TOKEN uv run pytest tests/sdk/validator/ -k "null or nat or nan or normalize"` ✅ (NaT regression tests still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)