### PR TITLE
fix: use UTF-8 (not OS locale) for YAML/JSON/text file I/O

### DIFF
--- a/src/mxcp/sdk/core/config/loader.py
+++ b/src/mxcp/sdk/core/config/loader.py
@@ -59,7 +59,8 @@ def load_resolver_config(config_path: Path | None = None) -> ResolverConfigModel
 
     # Load the YAML file
     try:
-        with open(config_path) as f:
+        # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+        with open(config_path, "rb") as f:
             raw_config = yaml.safe_load(f)
     except Exception as e:
         raise ValueError(f"Failed to parse YAML config file {config_path}: {e}") from e

--- a/src/mxcp/sdk/core/config/processor.py
+++ b/src/mxcp/sdk/core/config/processor.py
@@ -352,7 +352,8 @@ class ResolverEngine:
             raise FileNotFoundError(f"Configuration file not found: {file_path}")
 
         try:
-            with open(file_path) as f:
+            # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+            with open(file_path, "rb") as f:
                 config_data = yaml.safe_load(f)
         except yaml.YAMLError as e:
             raise ValueError(f"Invalid YAML in {file_path}: {e}") from e

--- a/src/mxcp/server/core/config/site_config.py
+++ b/src/mxcp/server/core/config/site_config.py
@@ -54,7 +54,8 @@ def load_site_config(repo_path: Path | None = None) -> SiteConfigModel:
     if not config_path.exists():
         raise FileNotFoundError(f"mxcp-site.yml not found at {config_path}")
 
-    with open(config_path) as f:
+    # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+    with open(config_path, "rb") as f:
         config = yaml.safe_load(f) or {}
 
     # Check for legacy version format and provide migration guidance (stops execution)

--- a/src/mxcp/server/core/config/user_config.py
+++ b/src/mxcp/server/core/config/user_config.py
@@ -51,7 +51,8 @@ def load_user_config(
             return _generate_default_config(site_config)
         raise FileNotFoundError(f"MXCP user config not found at {path}")
 
-    with open(path) as f:
+    # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+    with open(path, "rb") as f:
         config_data = yaml.safe_load(f) or {}
 
     if not isinstance(config_data, dict):

--- a/src/mxcp/server/definitions/endpoints/loader.py
+++ b/src/mxcp/server/definitions/endpoints/loader.py
@@ -152,7 +152,8 @@ class EndpointLoader:
 
         for f in directory.rglob("*.yml"):
             try:
-                with open(f) as file:
+                # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+                with open(f, "rb") as file:
                     data = yaml.safe_load(file)
 
                     if not data:
@@ -267,7 +268,8 @@ class EndpointLoader:
             for f in search_dir.rglob("*.yml"):
                 logger.debug(f"Checking file: {f}")
                 try:
-                    with open(f) as file:
+                    # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+                    with open(f, "rb") as file:
                         data = yaml.safe_load(file) or {}
 
                     model = EndpointDefinitionModel.model_validate(data)

--- a/src/mxcp/server/definitions/evals/loader.py
+++ b/src/mxcp/server/definitions/evals/loader.py
@@ -55,7 +55,8 @@ def discover_eval_files(
     # Find all YAML files in the evals directory
     for file_path in evals_dir.rglob("*.yml"):
         try:
-            with open(file_path) as f:
+            # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+            with open(file_path, "rb") as f:
                 data = yaml.safe_load(f) or {}
 
             # Check if this is a mxcp eval file

--- a/src/mxcp/server/interfaces/cli/evals.py
+++ b/src/mxcp/server/interfaces/cli/evals.py
@@ -313,7 +313,8 @@ async def _evals_impl(
             if not file_path.exists():
                 raise click.BadParameter(f"User context file not found: {file_path}")
             try:
-                with open(file_path) as f:
+                # Binary mode: let json detect the encoding (UTF-8/16/32) rather than the OS locale.
+                with open(file_path, "rb") as f:
                     context_data = json.load(f)
             except json.JSONDecodeError as e:
                 raise click.BadParameter(

--- a/src/mxcp/server/interfaces/cli/init.py
+++ b/src/mxcp/server/interfaces/cli/init.py
@@ -41,7 +41,8 @@ def check_project_exists_in_user_config(project_name: str) -> bool:
         return False
 
     try:
-        with open(config_path) as f:
+        # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+        with open(config_path, "rb") as f:
             config = yaml.safe_load(f)
 
         if not config:
@@ -57,7 +58,7 @@ def create_mxcp_site_yml(target_dir: Path, project_name: str, profile_name: str)
     """Create the mxcp-site.yml file with the given project and profile names."""
     config = {"mxcp": 1, "project": project_name, "profile": profile_name}
 
-    with open(target_dir / "mxcp-site.yml", "w") as f:
+    with open(target_dir / "mxcp-site.yml", "w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=False)
 
 
@@ -90,7 +91,7 @@ def create_hello_world_files(target_dir: Path) -> None:
     hello_world_sql = """SELECT 'Hello, ' || $name || '!' as greeting
 """
 
-    with open(target_dir / "sql" / "hello-world.sql", "w") as f:
+    with open(target_dir / "sql" / "hello-world.sql", "w", encoding="utf-8") as f:
         f.write(hello_world_sql)
 
     # Create hello-world.yml in the tools directory
@@ -113,7 +114,7 @@ def create_hello_world_files(target_dir: Path) -> None:
         },
     }
 
-    with open(target_dir / "tools" / "hello-world.yml", "w") as f:
+    with open(target_dir / "tools" / "hello-world.yml", "w", encoding="utf-8") as f:
         yaml.dump(hello_world_yml, f, default_flow_style=False, sort_keys=False)
 
 
@@ -385,7 +386,7 @@ def init(
                 claude_config = generate_claude_config(target_dir, project)
                 config_path = target_dir / "server_config.json"
 
-                with open(config_path, "w") as f:
+                with open(config_path, "w", encoding="utf-8") as f:
                     json.dump(claude_config, f, indent=2)
 
                 click.echo("✓ Generated server_config.json for Claude Desktop")

--- a/src/mxcp/server/interfaces/cli/query.py
+++ b/src/mxcp/server/interfaces/cli/query.py
@@ -136,7 +136,8 @@ async def _query(
             if not file_path.exists():
                 raise click.BadParameter(f"JSON file not found: {file_path}")
             try:
-                with open(file_path) as f:
+                # Binary mode: let json detect the encoding (UTF-8/16/32) rather than the OS locale.
+                with open(file_path, "rb") as f:
                     value = json.load(f)
             except json.JSONDecodeError as e:
                 raise click.BadParameter(f"Invalid JSON in file {file_path}: {e}") from e
@@ -146,7 +147,8 @@ async def _query(
     # Get SQL query
     query_sql = sql
     if file:
-        with open(file) as f:
+        # Plain text (.sql): no embedded encoding marker, so declare UTF-8 explicitly.
+        with open(file, encoding="utf-8") as f:
             query_sql = f.read()
 
     # Ensure we have a query to execute

--- a/src/mxcp/server/interfaces/cli/run.py
+++ b/src/mxcp/server/interfaces/cli/run.py
@@ -174,7 +174,8 @@ async def _run_endpoint_impl(
             if not file_path.exists():
                 raise click.BadParameter(f"User context file not found: {file_path}")
             try:
-                with open(file_path) as f:
+                # Binary mode: let json detect the encoding (UTF-8/16/32) rather than the OS locale.
+                with open(file_path, "rb") as f:
                     context_data = json.load(f)
             except json.JSONDecodeError as e:
                 raise click.BadParameter(
@@ -207,7 +208,8 @@ async def _run_endpoint_impl(
             if not file_path.exists():
                 raise click.BadParameter(f"Request headers file not found: {file_path}")
             try:
-                with open(file_path) as f:
+                # Binary mode: let json detect the encoding (UTF-8/16/32) rather than the OS locale.
+                with open(file_path, "rb") as f:
                     headers = json.load(f)
             except json.JSONDecodeError as e:
                 raise click.BadParameter(
@@ -240,7 +242,8 @@ async def _run_endpoint_impl(
             if not file_path.exists():
                 raise click.BadParameter(f"JSON file not found: {file_path}")
             try:
-                with open(file_path) as f:
+                # Binary mode: let json detect the encoding (UTF-8/16/32) rather than the OS locale.
+                with open(file_path, "rb") as f:
                     value = json.load(f)
             except json.JSONDecodeError as e:
                 raise click.BadParameter(f"Invalid JSON in file {file_path}: {e}") from e

--- a/src/mxcp/server/interfaces/cli/test.py
+++ b/src/mxcp/server/interfaces/cli/test.py
@@ -310,7 +310,8 @@ async def _test_impl(
             if not file_path.exists():
                 raise click.BadParameter(f"User context file not found: {file_path}")
             try:
-                with open(file_path) as f:
+                # Binary mode: let json detect the encoding (UTF-8/16/32) rather than the OS locale.
+                with open(file_path, "rb") as f:
                     context_data = json.load(f)
             except json.JSONDecodeError as e:
                 raise click.BadParameter(
@@ -343,7 +344,8 @@ async def _test_impl(
             if not file_path.exists():
                 raise click.BadParameter(f"Request headers file not found: {file_path}")
             try:
-                with open(file_path) as f:
+                # Binary mode: let json detect the encoding (UTF-8/16/32) rather than the OS locale.
+                with open(file_path, "rb") as f:
                     headers = json.load(f)
             except json.JSONDecodeError as e:
                 raise click.BadParameter(

--- a/src/mxcp/server/services/dbt/runner.py
+++ b/src/mxcp/server/services/dbt/runner.py
@@ -34,7 +34,8 @@ def _load_profiles() -> dict[str, Any]:
     """Load existing dbt profiles or return empty dict."""
     profiles_path = _get_dbt_profiles_path()
     if profiles_path.exists():
-        with open(profiles_path) as f:
+        # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+        with open(profiles_path, "rb") as f:
             return yaml.safe_load(f) or {}
     return {}
 
@@ -43,7 +44,8 @@ def _load_dbt_project() -> dict[str, Any]:
     """Load existing dbt_project.yml or return empty dict."""
     project_path = _get_dbt_project_path()
     if project_path.exists():
-        with open(project_path) as f:
+        # Binary mode: let PyYAML detect the encoding (UTF-8/16) rather than the OS locale.
+        with open(project_path, "rb") as f:
             return yaml.safe_load(f) or {}
     return {}
 
@@ -56,7 +58,7 @@ def _save_profiles(profiles: dict[str, Any]) -> None:
 
     # Write to temp file first
     temp_path = profiles_path.with_suffix(".yml.tmp")
-    with open(temp_path, "w") as f:
+    with open(temp_path, "w", encoding="utf-8") as f:
         yaml.safe_dump(profiles, f, default_flow_style=False)
 
     # Atomic rename
@@ -69,7 +71,7 @@ def _save_dbt_project(project_config: dict[str, Any]) -> None:
 
     # Write to temp file first
     temp_path = project_path.with_suffix(".yml.tmp")
-    with open(temp_path, "w") as f:
+    with open(temp_path, "w", encoding="utf-8") as f:
         yaml.safe_dump(project_config, f, default_flow_style=False)
 
     # Atomic rename

--- a/src/mxcp/server/services/drift/checker.py
+++ b/src/mxcp/server/services/drift/checker.py
@@ -30,7 +30,8 @@ def load_and_validate_snapshot(snapshot_path: Path) -> DriftSnapshot:
     if not snapshot_path.exists():
         raise FileNotFoundError(f"Snapshot file not found: {snapshot_path}")
 
-    with open(snapshot_path) as f:
+    # Binary mode: let json detect the encoding (UTF-8/16/32) rather than the OS locale.
+    with open(snapshot_path, "rb") as f:
         snapshot_data = json.load(f)
 
     # Validate version

--- a/src/mxcp/server/services/drift/snapshot.py
+++ b/src/mxcp/server/services/drift/snapshot.py
@@ -173,7 +173,7 @@ async def generate_snapshot(
                 resources=resources,
             )
             if not dry_run:
-                with open(drift_path, "w") as f:
+                with open(drift_path, "w", encoding="utf-8") as f:
                     json.dump(snapshot.model_dump(mode="json", exclude_none=True), f, indent=2)
                 logger.info(f"Wrote drift snapshot to {drift_path}")
             else:

--- a/tests/server/test_endpoint_loader_encoding.py
+++ b/tests/server/test_endpoint_loader_encoding.py
@@ -61,6 +61,23 @@ def _default_encoding_is_utf8() -> bool:
     return locale.getpreferredencoding(False).lower().replace("-", "") == "utf8"
 
 
+def _tool_yaml(description: str) -> str:
+    """A *complete*, schema-valid tool definition with the given description.
+
+    ``source`` is required by ToolDefinitionModel (exactly one of code/file), so
+    it must be present — otherwise validation fails with "tool.source: Field
+    required" and masks the encoding behaviour we're actually testing.
+    """
+    return (
+        "mxcp: 1\n"
+        "tool:\n"
+        "  name: summarize\n"
+        f"  description: {description!r}\n"
+        "  source:\n"
+        "    code: 'SELECT 1'\n"
+    )
+
+
 @pytest.mark.skipif(
     _default_encoding_is_utf8(),
     reason=(
@@ -84,14 +101,10 @@ def test_tool_description_survives_utf8_round_trip(tmp_path, monkeypatch):
     tools_dir = tmp_path / "tools"
     tools_dir.mkdir()
 
-    tool_yaml = (
-        "mxcp: 1\n"
-        "tool:\n"
-        "  name: summarize\n"
-        f"  description: {NON_ASCII_DESCRIPTION!r}\n"
-    )
     # Write the definition explicitly as UTF-8, exactly as an editor would.
-    (tools_dir / "summarize.yml").write_text(tool_yaml, encoding="utf-8")
+    (tools_dir / "summarize.yml").write_text(
+        _tool_yaml(NON_ASCII_DESCRIPTION), encoding="utf-8"
+    )
 
     # find_repo_root() walks up from the cwd looking for mxcp-site.yml.
     monkeypatch.chdir(tmp_path)
@@ -137,11 +150,7 @@ def test_tool_description_mojibake_round_trip(tmp_path, monkeypatch):
     tools_dir = tmp_path / "tools"
     tools_dir.mkdir()
     (tools_dir / "summarize.yml").write_text(
-        "mxcp: 1\n"
-        "tool:\n"
-        "  name: summarize\n"
-        f"  description: {MOJIBAKE_DESCRIPTION!r}\n",
-        encoding="utf-8",
+        _tool_yaml(MOJIBAKE_DESCRIPTION), encoding="utf-8"
     )
     monkeypatch.chdir(tmp_path)
 
@@ -174,11 +183,7 @@ def test_discover_tools_preserves_utf8_description(tmp_path, monkeypatch):
     tools_dir = tmp_path / "tools"
     tools_dir.mkdir()
     (tools_dir / "summarize.yml").write_text(
-        "mxcp: 1\n"
-        "tool:\n"
-        "  name: summarize\n"
-        f"  description: {NON_ASCII_DESCRIPTION!r}\n",
-        encoding="utf-8",
+        _tool_yaml(NON_ASCII_DESCRIPTION), encoding="utf-8"
     )
     monkeypatch.chdir(tmp_path)
 

--- a/tests/server/test_endpoint_loader_encoding.py
+++ b/tests/server/test_endpoint_loader_encoding.py
@@ -102,9 +102,7 @@ def test_tool_description_survives_utf8_round_trip(tmp_path, monkeypatch):
     tools_dir.mkdir()
 
     # Write the definition explicitly as UTF-8, exactly as an editor would.
-    (tools_dir / "summarize.yml").write_text(
-        _tool_yaml(NON_ASCII_DESCRIPTION), encoding="utf-8"
-    )
+    (tools_dir / "summarize.yml").write_text(_tool_yaml(NON_ASCII_DESCRIPTION), encoding="utf-8")
 
     # find_repo_root() walks up from the cwd looking for mxcp-site.yml.
     monkeypatch.chdir(tmp_path)
@@ -149,9 +147,7 @@ def test_tool_description_mojibake_round_trip(tmp_path, monkeypatch):
     )
     tools_dir = tmp_path / "tools"
     tools_dir.mkdir()
-    (tools_dir / "summarize.yml").write_text(
-        _tool_yaml(MOJIBAKE_DESCRIPTION), encoding="utf-8"
-    )
+    (tools_dir / "summarize.yml").write_text(_tool_yaml(MOJIBAKE_DESCRIPTION), encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     loader = EndpointLoader(SiteConfigModel(project="enc_test", profile="default"))
@@ -182,9 +178,7 @@ def test_discover_tools_preserves_utf8_description(tmp_path, monkeypatch):
     )
     tools_dir = tmp_path / "tools"
     tools_dir.mkdir()
-    (tools_dir / "summarize.yml").write_text(
-        _tool_yaml(NON_ASCII_DESCRIPTION), encoding="utf-8"
-    )
+    (tools_dir / "summarize.yml").write_text(_tool_yaml(NON_ASCII_DESCRIPTION), encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     loader = EndpointLoader(SiteConfigModel(project="enc_test", profile="default"))

--- a/tests/server/test_endpoint_loader_encoding.py
+++ b/tests/server/test_endpoint_loader_encoding.py
@@ -37,10 +37,24 @@ import pytest
 from mxcp.server.core.config.models import SiteConfigModel
 from mxcp.server.definitions.endpoints.loader import EndpointLoader
 
-# A description with characters that are multi-byte in UTF-8 and corrupt cleanly
-# under cp1252 (every constituent byte is defined in cp1252, so we get mojibake
-# rather than a hard decode error — which makes the equality assertion precise).
-NON_ASCII_DESCRIPTION = "Summarize café revenue — uses “smart” rounding © 2026"
+# Two distinct UTF-8 failure modes under a cp1252 default decode:
+#
+# 1. HARD DECODE ERROR — the closing curly quote “”” is UTF-8 ``e2 80 9d`` and
+#    byte ``0x9d`` is UNDEFINED in cp1252, so the decode raises
+#    ``UnicodeDecodeError`` before PyYAML sees anything. In ``load_endpoint`` the
+#    broad ``except Exception`` swallows it and returns ``None`` (a silent
+#    failure); ``discover_tools`` surfaces it as the error element of its tuple.
+HARD_ERROR_DESCRIPTION = "Summarize café revenue — uses “smart” rounding © 2026"
+
+# 2. SILENT MOJIBAKE — every byte of café / em-dash / © IS defined in cp1252, so
+#    nothing raises: the file decodes successfully into corrupted text and the
+#    load *succeeds* with a wrong description. e.g. the em-dash ``—`` (UTF-8
+#    ``e2 80 94``) becomes the three characters ``â€"``. Here the equality
+#    assertion — not an exception — is what catches the bug.
+MOJIBAKE_DESCRIPTION = "Summarize café revenue — 100% © 2026"
+
+# Backwards-compatible alias used by the original two tests below.
+NON_ASCII_DESCRIPTION = HARD_ERROR_DESCRIPTION
 
 
 def _default_encoding_is_utf8() -> bool:
@@ -55,7 +69,13 @@ def _default_encoding_is_utf8() -> bool:
     ),
 )
 def test_tool_description_survives_utf8_round_trip(tmp_path, monkeypatch):
-    """A UTF-8 tool description must load unchanged through the endpoint loader."""
+    """HARD-ERROR path: a UTF-8 description with a cp1252-undefined byte.
+
+    The ``“”`` quotes make the cp1252 decode raise ``UnicodeDecodeError``, which
+    ``load_endpoint`` swallows into ``None`` — so on Windows this fails at the
+    "loader returned None" assertion rather than the equality check. See
+    :data:`MOJIBAKE_DESCRIPTION` / the next test for the silent-corruption case.
+    """
     # --- Arrange: a minimal mxcp project on disk ---------------------------
     (tmp_path / "mxcp-site.yml").write_text(
         "mxcp: 1\nproject: enc_test\nprofile: default\n",
@@ -91,6 +111,53 @@ def test_tool_description_survives_utf8_round_trip(tmp_path, monkeypatch):
         f"  expected: {NON_ASCII_DESCRIPTION!r}\n"
         f"  got:      {model.tool.description!r}\n"
         "This is the UTF-8-read-as-cp1252 bug: open() needs encoding='utf-8'."
+    )
+
+
+@pytest.mark.skipif(
+    _default_encoding_is_utf8(),
+    reason=(
+        "Platform default text encoding is UTF-8, so the cp1252 mis-decode "
+        "cannot occur here. Run this on Windows (cp1252 locale) to exercise it."
+    ),
+)
+def test_tool_description_mojibake_round_trip(tmp_path, monkeypatch):
+    """SILENT-MOJIBAKE path: cp1252-safe bytes that decode without raising.
+
+    Every byte of café / em-dash / © is defined in cp1252, so on Windows the
+    loader does NOT raise — it returns a valid model whose description is
+    silently corrupted (e.g. ``—`` -> ``â€"``). The load "succeeds", so the
+    equality assertion below is the only thing that catches the corruption.
+    Passes everywhere once the loader opens files with ``encoding="utf-8"``.
+    """
+    (tmp_path / "mxcp-site.yml").write_text(
+        "mxcp: 1\nproject: enc_test\nprofile: default\n",
+        encoding="utf-8",
+    )
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    (tools_dir / "summarize.yml").write_text(
+        "mxcp: 1\n"
+        "tool:\n"
+        "  name: summarize\n"
+        f"  description: {MOJIBAKE_DESCRIPTION!r}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    loader = EndpointLoader(SiteConfigModel(project="enc_test", profile="default"))
+    result = loader.load_endpoint("tool", "summarize")
+
+    # The load itself succeeds here (no UnicodeDecodeError) — that is the trap.
+    assert result is not None, "loader returned None — endpoint failed to load"
+    _path, model = result
+    assert model.tool is not None
+    assert model.tool.description == MOJIBAKE_DESCRIPTION, (
+        "Tool description was silently corrupted (mojibake) by the loader.\n"
+        f"  expected: {MOJIBAKE_DESCRIPTION!r}\n"
+        f"  got:      {model.tool.description!r}\n"
+        "The load did not raise — it returned wrong text. open() needs "
+        "encoding='utf-8'."
     )
 
 

--- a/tests/server/test_endpoint_loader_encoding.py
+++ b/tests/server/test_endpoint_loader_encoding.py
@@ -1,0 +1,138 @@
+"""Encoding regression test for the endpoint loader core stack.
+
+Background
+----------
+Tool/resource/prompt definition files are authored as UTF-8. The loader reads
+them with ``open(f)`` (text mode, no ``encoding=``). In text mode Python decodes
+the bytes using ``locale.getpreferredencoding(False)`` *before* PyYAML ever sees
+them. On Windows with a Western locale that default is cp1252 (Windows-1252), so
+a UTF-8 file containing non-ASCII characters in a description gets silently
+mangled into mojibake (or raises ``UnicodeDecodeError``).
+
+This test exercises the real core stack:
+
+    open(f) -> yaml.safe_load -> EndpointDefinitionModel.model_validate
+            -> model.tool.description
+
+It writes a tool YAML as UTF-8 with non-ASCII characters in the description and
+asserts the description survives a round trip through the loader.
+
+Where it runs
+-------------
+* On a platform whose default text encoding is already UTF-8 (Linux/macOS CI,
+  or any interpreter in UTF-8 mode) the bug cannot manifest, so the test SKIPS
+  rather than reporting a misleading pass.
+* On Windows with a cp1252 default it RUNS: it fails (mojibake or
+  UnicodeDecodeError) before the fix, and passes once the loader opens files
+  with ``encoding="utf-8"``.
+
+Run it from Windows with:  pytest tests/server/test_endpoint_loader_encoding.py -v
+"""
+
+import locale
+import os
+
+import pytest
+
+from mxcp.server.core.config.models import SiteConfigModel
+from mxcp.server.definitions.endpoints.loader import EndpointLoader
+
+# A description with characters that are multi-byte in UTF-8 and corrupt cleanly
+# under cp1252 (every constituent byte is defined in cp1252, so we get mojibake
+# rather than a hard decode error — which makes the equality assertion precise).
+NON_ASCII_DESCRIPTION = "Summarize café revenue — uses “smart” rounding © 2026"
+
+
+def _default_encoding_is_utf8() -> bool:
+    return locale.getpreferredencoding(False).lower().replace("-", "") == "utf8"
+
+
+@pytest.mark.skipif(
+    _default_encoding_is_utf8(),
+    reason=(
+        "Platform default text encoding is UTF-8, so the cp1252 mis-decode "
+        "cannot occur here. Run this on Windows (cp1252 locale) to exercise it."
+    ),
+)
+def test_tool_description_survives_utf8_round_trip(tmp_path, monkeypatch):
+    """A UTF-8 tool description must load unchanged through the endpoint loader."""
+    # --- Arrange: a minimal mxcp project on disk ---------------------------
+    (tmp_path / "mxcp-site.yml").write_text(
+        "mxcp: 1\nproject: enc_test\nprofile: default\n",
+        encoding="utf-8",
+    )
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+
+    tool_yaml = (
+        "mxcp: 1\n"
+        "tool:\n"
+        "  name: summarize\n"
+        f"  description: {NON_ASCII_DESCRIPTION!r}\n"
+    )
+    # Write the definition explicitly as UTF-8, exactly as an editor would.
+    (tools_dir / "summarize.yml").write_text(tool_yaml, encoding="utf-8")
+
+    # find_repo_root() walks up from the cwd looking for mxcp-site.yml.
+    monkeypatch.chdir(tmp_path)
+
+    site_config = SiteConfigModel(project="enc_test", profile="default")
+    loader = EndpointLoader(site_config)
+
+    # --- Act: run the real core stack --------------------------------------
+    result = loader.load_endpoint("tool", "summarize")
+
+    # --- Assert ------------------------------------------------------------
+    assert result is not None, "loader returned None — endpoint failed to load"
+    _path, model = result
+    assert model.tool is not None
+    assert model.tool.description == NON_ASCII_DESCRIPTION, (
+        "Tool description was corrupted on the way through the loader.\n"
+        f"  expected: {NON_ASCII_DESCRIPTION!r}\n"
+        f"  got:      {model.tool.description!r}\n"
+        "This is the UTF-8-read-as-cp1252 bug: open() needs encoding='utf-8'."
+    )
+
+
+@pytest.mark.skipif(
+    _default_encoding_is_utf8(),
+    reason="Platform default is UTF-8; cp1252 mis-decode cannot occur here.",
+)
+def test_discover_tools_preserves_utf8_description(tmp_path, monkeypatch):
+    """Same bug via the discovery path (discover_tools -> _discover_in_directory)."""
+    (tmp_path / "mxcp-site.yml").write_text(
+        "mxcp: 1\nproject: enc_test\nprofile: default\n",
+        encoding="utf-8",
+    )
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    (tools_dir / "summarize.yml").write_text(
+        "mxcp: 1\n"
+        "tool:\n"
+        "  name: summarize\n"
+        f"  description: {NON_ASCII_DESCRIPTION!r}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    loader = EndpointLoader(SiteConfigModel(project="enc_test", profile="default"))
+    discovered = loader.discover_tools()
+
+    # Exactly one file, loaded without error.
+    assert len(discovered) == 1
+    _path, model, error = discovered[0]
+    assert error is None, f"loader reported an error: {error}"
+    assert model is not None and model.tool is not None
+    assert model.tool.description == NON_ASCII_DESCRIPTION
+
+
+def test_environment_report():
+    """Always-on: print the encoding context so a Windows run is self-documenting.
+
+    Not an assertion — it makes the skip/run decision auditable in CI logs, so a
+    green result can't be mistaken for 'tested but passed' when it was skipped.
+    """
+    print()
+    print(f"locale.getpreferredencoding(False) = {locale.getpreferredencoding(False)!r}")
+    print(f"PYTHONUTF8 = {os.environ.get('PYTHONUTF8')!r}")
+    print(f"sys default encoding utf-8? {_default_encoding_is_utf8()}")


### PR DESCRIPTION
## Description
On Windows, every `open()` in the runtime used text mode with no `encoding=`, so Python decoded/encoded files with the OS locale codepage (cp1252) instead of UTF-8. Depending on the bytes, non-ASCII content in YAML/JSON files was either silently corrupted into mojibake or raised `UnicodeDecodeError`. The endpoint loader was the entry point that surfaced this (a tool `description` with `café`, `—`, `©`, or smart quotes failed to load), but the same bug affected ~26 file-I/O sites across config, dbt, drift, the SDK, and the CLI.

This PR adds a regression test that reproduces the bug on Windows, then fixes the whole class of sites with a per-purpose encoding policy.

**Fix policy:**
- **Readers of self-describing formats (YAML, JSON)** → open in **binary mode** and let the parser detect the encoding (PyYAML: UTF-8/16; `json`: UTF-8/16/32 per RFC 8259). Locale-immune *and* spec-faithful — a legitimately UTF-16 file stays valid rather than being rejected by a hardcoded UTF-8 assumption.
- **Readers of opaque text (`.sql`)** → explicit `encoding="utf-8"` (no marker to detect).
- **Writers** → explicit `encoding="utf-8"` (no library detection on output; we declare the encoding).

**Sites fixed (14 files, 26 call sites):** `site_config`, `user_config`, `evals/loader`, `endpoints/loader` (×2), `dbt/runner` (2 reads + 2 writes), SDK config `loader`/`processor`, `cli/init` (1 read + 4 writes), `drift/checker` (read) + `drift/snapshot` (write), and the `cli` `run`/`test`/`evals`/`query` JSON `@file` readers + the `query` SQL reader.

**Test:** `tests/server/test_endpoint_loader_encoding.py` exercises the real loader stack with two failure modes — a hard `UnicodeDecodeError` (cp1252-undefined byte, swallowed to `None`) and silent mojibake (cp1252-safe bytes, caught by an equality assertion). It skips where the platform default is already UTF-8 (Linux/macOS) so a green run there isn't mistaken for coverage, and runs on Windows where it fails before the fix and passes after.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvement
- [ ] 🔒 Security fix

## Testing
- [ ] Tests pass locally with `uv run pytest` — ran the affected suites (`tests/sdk/core/test_config.py`, `tests/server/test_endpoint_loader_encoding.py`); not the full suite. One unrelated failure (`test_onepassword_resolver_validation`) is pre-existing on this machine (1Password creds present) and reproduces on clean `main`.
- [x] Linting passes with `uv run ruff check .` (on changed files)
- [x] Code formatting passes with `uv run black --check .` (on changed files)
- [x] Type checking passes with `uv run mypy .` (on the 14 changed source files)
- [x] Added tests for new functionality (the encoding regression test)
- [ ] Updated documentation (if applicable)

## Security Considerations
- [x] This change does not introduce security vulnerabilities
- [x] Sensitive data handling reviewed (if applicable) — encoding handling of config/credential files reviewed; the audit JSONL backend and validator schema loader already pinned UTF-8 and were left unchanged.
- [ ] Policy enforcement implications considered (if applicable)

## Breaking Changes
None. Behavior is unchanged for valid UTF-8 files (the existing universe); the fix additionally makes UTF-16/UTF-32 inputs work and corrects Windows non-ASCII handling.

## Additional Notes
- The encoding regression test **skips on Linux/macOS** and only runs on a cp1252 Windows host. A follow-up could force the decode codec in-test so the bug is exercised deterministically on every platform (including CI) rather than relying on the runner's locale.
- Two existing read sites were already correct and left as-is: `sdk/validator/decorators/loaders.py` (`read_text(encoding="utf-8")`) and the audit JSONL backend (`encoding="utf-8"` throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
